### PR TITLE
Make resultType stricter to catch errors at compile time

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackConnection.java
@@ -16,5 +16,5 @@ public interface SaltStackConnection {
      * @return object of type given by resultType
      * @throws SaltStackException if the request was not successful
      */
-    <T> T getResult(Type resultType, String data) throws SaltStackException;
+    <T> T getResult(Class<T> resultType, String data) throws SaltStackException;
 }

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
@@ -45,7 +45,7 @@ public class SaltStackHttpClientConnection implements SaltStackConnection {
      * {@inheritDoc}
      */
     @Override
-    public <T> T getResult(Type resultType, String data) throws SaltStackException {
+    public <T> T getResult(Class<T> resultType, String data) throws SaltStackException {
         HttpClientBuilder httpClientBuilder = HttpClients.custom();
 
         // Configure proxy if specified on configuration

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
@@ -42,7 +42,7 @@ public class SaltStackJDKConnection implements SaltStackConnection {
      * {@inheritDoc}
      */
     @Override
-    public <T> T getResult(Type resultType, String data) throws SaltStackException {
+    public <T> T getResult(Class<T> resultType, String data) throws SaltStackException {
         return request(resultType, "POST", data);
     }
 


### PR DESCRIPTION
This makes writing 
```java 
SaltStackTokenResult result = connectionFactory.create("/login", config).getResult(Integer.class, json.toString())
```
a compile time error instead of a runtime error.