### PR TITLE
Use descriptive method name, not API endpoint

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -147,7 +147,7 @@ public class SaltStackClient {
      * @return object representing the scheduled job
      * @throws SaltStackException if anything goes wrong
      */
-    public SaltStackJob minions(String target, String function, List<String> args,
+    public SaltStackJob startJob(String target, String function, List<String> args,
             Map<String, String> kwargs) throws SaltStackException {
         // Setup lowstate data to send as JSON
         JsonObject json = new JsonObject();

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -147,7 +147,7 @@ public class SaltStackClient {
      * @return object representing the scheduled job
      * @throws SaltStackException if anything goes wrong
      */
-    public SaltStackJob startJob(String target, String function, List<String> args,
+    public SaltStackJob startCommand(String target, String function, List<String> args,
             Map<String, String> kwargs) throws SaltStackException {
         // Setup lowstate data to send as JSON
         JsonObject json = new JsonObject();


### PR DESCRIPTION
At the moment, the methods in SaltStackClient are called like the salt netapi endpoints they are connecting to. If this method naming scheme is followed, at some point we well have overloaded methods of the same names calling their netapi endpoints with POST and GET respectively. While this will work, because the method signatures will be different, it's highly unintuitive if the users of our library do not know the netapi (and I think they shouldn't be expected to). 

So, a simple question in a short pull request: would you consider a different, more descriptive naming scheme for these methods, and shield the user of this library from the details of the salt netapi, or was this a deliberate decision?