### PR TITLE
Make working with the SaltStackClientConfig more typesafe

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -1,6 +1,7 @@
 package com.suse.saltstack.netapi.client;
 
 import com.suse.saltstack.netapi.config.SaltStackClientConfig;
+import static com.suse.saltstack.netapi.config.SaltStackClientConfig.*;
 import com.suse.saltstack.netapi.config.SaltStackProxySettings;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.SaltStackParser;
@@ -12,7 +13,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-import java.net.URISyntaxException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public class SaltStackClient {
      * @param url the SaltStack URL
      * @throws SaltStackException
      */
-    public SaltStackClient(String url) throws SaltStackException {
+    public SaltStackClient(URI url) {
         this(url, new SaltStackHttpClientConnectionFactory());
     }
 
@@ -44,16 +45,9 @@ public class SaltStackClient {
      * @param connectionFactory Connection Factory implementation
      * @throws SaltStackException
      */
-    public SaltStackClient(String url, SaltStackConnectionFactory connectionFactory)
-            throws SaltStackException {
+    public SaltStackClient(URI url, SaltStackConnectionFactory connectionFactory) {
         // Put the URL in the config
-        if (url != null) {
-            try {
-                config.setUrl(url);
-            } catch (URISyntaxException e) {
-                throw new SaltStackException(e);
-            }
-        }
+        config.put(URL, url);
         this.connectionFactory = connectionFactory;
     }
 
@@ -73,13 +67,13 @@ public class SaltStackClient {
      */
     public void setProxy(SaltStackProxySettings settings) {
         if (settings.getHostname() != null) {
-            config.put(SaltStackClientConfig.PROXY_HOSTNAME, settings.getHostname());
-            config.put(SaltStackClientConfig.PROXY_PORT, String.valueOf(settings.getPort()));
+            config.put(PROXY_HOSTNAME, settings.getHostname());
+            config.put(PROXY_PORT, settings.getPort());
         }
         if (settings.getUsername() != null) {
-            config.put(SaltStackClientConfig.PROXY_USERNAME, settings.getUsername());
+            config.put(PROXY_USERNAME, settings.getUsername());
             if (settings.getPassword() != null) {
-                config.put(SaltStackClientConfig.PROXY_PASSWORD, settings.getPassword());
+                config.put(PROXY_PASSWORD, settings.getPassword());
             }
         }
     }
@@ -116,7 +110,7 @@ public class SaltStackClient {
 
         // For whatever reason they return a list of tokens here, take the first
         SaltStackToken token = result.getResult().get(0);
-        config.put(SaltStackClientConfig.TOKEN, token.getToken());
+        config.put(TOKEN, token.getToken());
         return token;
     }
 
@@ -130,7 +124,7 @@ public class SaltStackClient {
     public SaltStackResult<String> logout() throws SaltStackException {
         SaltStackResult<String> result = connectionFactory
                 .create("/logout", SaltStackParser.STRING, config).getResult(null);
-        config.remove(SaltStackClientConfig.TOKEN);
+        config.remove(TOKEN);
         return result;
     }
 

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
@@ -1,6 +1,7 @@
 package com.suse.saltstack.netapi.client;
 
 import com.suse.saltstack.netapi.config.SaltStackClientConfig;
+import static com.suse.saltstack.netapi.config.SaltStackClientConfig.*;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.SaltStackParser;
 import org.apache.http.HttpHost;
@@ -17,6 +18,8 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 import java.io.IOException;
+import java.net.URI;
+
 
 /**
  * Class representation of a connection to SaltStack for issuing API requests
@@ -54,15 +57,15 @@ public class SaltStackHttpClientConnection<T> implements SaltStackConnection<T> 
         HttpClientBuilder httpClientBuilder = HttpClients.custom();
 
         // Configure proxy if specified on configuration
-        String proxyHost = config.getProxyHostname();
+        String proxyHost = config.get(PROXY_HOSTNAME);
         if (proxyHost != null) {
-            int proxyPort = Integer.parseInt(config.getProxyPort());
+            int proxyPort = config.get(PROXY_PORT);
             HttpHost proxy = new HttpHost(proxyHost, proxyPort);
             httpClientBuilder.setProxy(proxy);
 
             // Proxy authentication
-            String proxyUsername = config.getProxyUsername();
-            String proxyPassword = config.getProxyPassword();
+            String proxyUsername = config.get(PROXY_USERNAME);
+            String proxyPassword = config.get(PROXY_PASSWORD);
             if (proxyUsername != null && proxyPassword != null) {
                 CredentialsProvider credentials = new BasicCredentialsProvider();
                 credentials.setCredentials(
@@ -74,7 +77,7 @@ public class SaltStackHttpClientConnection<T> implements SaltStackConnection<T> 
 
         try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
             // Prepare POST request
-            String uri = config.getUrl() + endpoint;
+            URI uri = config.get(URL).resolve(endpoint);
             HttpPost httpPost = new HttpPost(uri);
             httpPost.addHeader("Accept", "application/json");
 
@@ -85,7 +88,7 @@ public class SaltStackHttpClientConnection<T> implements SaltStackConnection<T> 
             }
 
             // Token authentication
-            String token = config.getToken();
+            String token = config.get(TOKEN);
             if (token != null) {
                 httpPost.addHeader("X-Auth-Token", token);
             }

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackRequestFactory.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackRequestFactory.java
@@ -1,6 +1,7 @@
 package com.suse.saltstack.netapi.client;
 
 import com.suse.saltstack.netapi.config.SaltStackClientConfig;
+import static com.suse.saltstack.netapi.config.SaltStackClientConfig.*;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -44,21 +45,20 @@ public class SaltStackRequestFactory {
     public HttpURLConnection initConnection(String method, String endpoint,
             SaltStackClientConfig config) throws IOException {
         // Init the connection
-        String uri = config.getUrl() + endpoint;
-        URL url = new URL(uri);
+        URL url = config.get(URL).resolve(endpoint).toURL();
         HttpURLConnection connection;
 
         // Optionally connect via a given proxy
-        String proxyHost = config.getProxyHostname();
+        String proxyHost = config.get(PROXY_HOSTNAME);
         if (proxyHost != null) {
-            int proxyPort = Integer.parseInt(config.getProxyPort());
+            int proxyPort = config.get(PROXY_PORT);
             Proxy proxy = new Proxy(Proxy.Type.HTTP,
                     new InetSocketAddress(proxyHost, proxyPort));
             connection = (HttpURLConnection) url.openConnection(proxy);
 
             // Proxy authentication
-            String proxyUsername = config.getProxyUsername();
-            String proxyPassword = config.getProxyPassword();
+            String proxyUsername = config.get(PROXY_USERNAME);
+            String proxyPassword = config.get(PROXY_PASSWORD);
             if (proxyUsername != null && proxyPassword != null) {
                 final String encoded = DatatypeConverter.printBase64Binary(
                         (proxyUsername + ':' + proxyPassword).getBytes());
@@ -73,7 +73,7 @@ public class SaltStackRequestFactory {
         connection.setRequestProperty("Accept", "application/json");
 
         // Token authentication
-        String token = config.getToken();
+        String token = config.get(TOKEN);
         if (token != null) {
             connection.setRequestProperty("X-Auth-Token", token);
         }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.assertEquals;
@@ -26,9 +27,9 @@ public class SaltStackClientTest {
     private SaltStackClient client;
 
     @Before
-    public void init() throws SaltStackException {
-        client = new SaltStackClient(
-                "http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
+    public void init() {
+        URI uri = URI.create("http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
+        client = new SaltStackClient(uri);
     }
 
     @Test

--- a/src/test/java/com/suse/saltstack/netapi/config/SaltStackClientConfigTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/config/SaltStackClientConfigTest.java
@@ -1,0 +1,35 @@
+package com.suse.saltstack.netapi.config;
+
+import static com.suse.saltstack.netapi.config.SaltStackClientConfig.*;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class SaltStackClientConfigTest {
+
+    @Test
+    public void testPutGetRemove() {
+        SaltStackClientConfig config = new SaltStackClientConfig();
+        Key<Integer> key = PROXY_PORT;
+
+        assertEquals("New empty config should return defaultValue", config.get(key), key.defaultValue);
+
+        Integer newValue = new Integer(123);
+        config.put(key, newValue);
+        assertEquals("Should return the new configured value", config.get(key), newValue);
+
+        config.put(key, key.defaultValue);
+        assertEquals("Should return the new configured value", config.get(key), key.defaultValue);
+
+        config.put(key, newValue);
+        assertEquals("Should return the new configured value", config.get(key), newValue);
+        config.put(key, null);
+        assertEquals("Should return the default value after putting in null", config.get(key), key.defaultValue);
+
+        config.put(key, newValue);
+        assertEquals("Should return the new configured value", config.get(key), newValue);
+        config.remove(key);
+        assertEquals("Should return the default value after removing the key", config.get(key), key.defaultValue);
+    }
+
+}


### PR DESCRIPTION
This replaces the current stringly typed `SaltStackClientConfig` with a statically typed key/value store that knows the type of each key. This shifts the burden of parsing the configuration values from the consumers side to the producers side. So everything querying the config for values does not have to deal with parsing and error handling of invalid values like `"hello"` as a port value. This also results in those invalid values being detected earlier (for example when the config is loaded from a file instead of when a value is used).

I would also suggest to generally make parameters stricter and ask for what is really needed instead of something that could potentially be parsed to what is needed. An example of this is the change [here](https://github.com/lucidd/saltstack-netapi-client-java/compare/config#diff-250997581e435e368654d6b84ccbe400R52) asking directly for a URI object instead of a String.
This reduces the overall error handling needed inside the API and and shifts it to the user of the API which should be fine since most argument parsing errors would probably result in an error that bubbles up to the user anyway.



I also experimented with a version that can prevent different sub types of `KeyValueStore` from mixing keys with each other but left it out for now since there is only one Configuration class right now. But it could be useful in the future.