### PR TITLE
Ignore all .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 
 # IntelliJ IDEA
 /.idea/
-/*.iml
+*.iml
 
 # Build and test artifacts
 /bin/


### PR DESCRIPTION
Intellij also puts `.iml` files in sub directories if they are configured as modules (for example having `main` and `test` configures as separate modules).