### PR TITLE
Add 'start' and 'expire' dates to token

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/results/Token.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/Token.java
@@ -1,5 +1,7 @@
 package com.suse.saltstack.netapi.results;
 
+import java.util.Date;
+
 public class Token {
 
     // String attributes
@@ -7,9 +9,8 @@ public class Token {
     private String token;
     private String user;
 
-    // TODO: Validity dates
-    // private Date start;
-    // private Date expire;
+    private Date start;
+    private Date expire;
 
     public String getEauth() {
         return eauth;
@@ -23,10 +24,11 @@ public class Token {
         return user;
     }
 
-//    public Date getStart() {
-//        return start;
-//    }
-//    public Date getExpire() {
-//        return expire;
-//    }
+    public Date getStart() {
+        return start;
+    }
+
+    public Date getExpire() {
+        return expire;
+    }
 }

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -1,8 +1,10 @@
 package com.suse.saltstack.netapi.parser;
 
+import com.google.gson.JsonParseException;
 import com.suse.saltstack.netapi.results.Job;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.results.Token;
+import java.util.Date;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -36,5 +38,13 @@ public class JsonParserTest {
         assertEquals("", "salt", result.getResult().get(0).getUser());
         assertEquals("", "pam", result.getResult().get(0).getEauth());
         assertEquals("", "f248284b655724ca8a86bcab4b8df608ebf5b08b", result.getResult().get(0).getToken());
+        assertEquals("", new Date(1423573511380L), result.getResult().get(0).getStart());
+        assertEquals("", new Date(1423616711380L), result.getResult().get(0).getExpire());
+    }
+
+    @Test(expected =  JsonParseException.class)
+    public void testSaltStackTokenParserWrongDate() throws Exception {
+        InputStream is = this.getClass().getResourceAsStream("/login_response_wrong_date.json");
+        JsonParser.TOKEN.parse(is);
     }
 }

--- a/src/test/resources/login_response_wrong_date.json
+++ b/src/test/resources/login_response_wrong_date.json
@@ -1,0 +1,16 @@
+{
+  "return": [
+    {
+      "perms": [
+        ".*",
+        "@wheel",
+        "@runner",
+        "@jobs"
+      ],
+      "start": "yesterday",
+      "token": "f248284b655724ca8a86bcab4b8df608ebf5b08b",
+      "user": "salt",
+      "eauth": "pam"
+    }
+  ]
+}


### PR DESCRIPTION
This patch adds dates to login token. For parsing dates, new
deserializer was added to SaltStackParser class.