### PR TITLE
Code and Javadoc cleanup

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -32,7 +32,6 @@ public class SaltStackClient {
      * Constructor for connecting to a given URL.
      *
      * @param url the SaltStack URL
-     * @throws SaltStackException
      */
     public SaltStackClient(URI url) {
         this(url, new SaltStackHttpClientConnectionFactory());
@@ -43,7 +42,6 @@ public class SaltStackClient {
      *
      * @param url the SaltStack URL
      * @param connectionFactory Connection Factory implementation
-     * @throws SaltStackException
      */
     public SaltStackClient(URI url, SaltStackConnectionFactory connectionFactory) {
         // Put the URL in the config

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackHttpClientConnection.java
@@ -102,8 +102,7 @@ public class SaltStackHttpClientConnection<T> implements SaltStackConnection<T> 
                 }
 
                 // Parse result type from the returned JSON
-                T result = parser.parse(response.getEntity().getContent());
-                return result;
+                return parser.parse(response.getEntity().getContent());
             }
         } catch (IOException e) {
             throw new SaltStackException(e);

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
@@ -48,7 +48,6 @@ public class SaltStackJDKConnection<T> implements SaltStackConnection<T> {
     /**
      * Perform HTTP request and parse the result into a given result type.
      *
-     * @param resultType the type of the result
      * @param method the HTTP method to use
      * @return object of type given by resultType
      * @throws SaltStackException in case of a problem

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
@@ -3,11 +3,9 @@ package com.suse.saltstack.netapi.client;
 import com.suse.saltstack.netapi.config.SaltStackClientConfig;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.SaltStackParser;
-import com.suse.saltstack.netapi.utils.SaltStackClientUtils;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 
 /**
@@ -55,7 +53,6 @@ public class SaltStackJDKConnection<T> implements SaltStackConnection<T> {
     private T request(String method, String data)
             throws SaltStackException {
         HttpURLConnection connection = null;
-        InputStream inputStream = null;
         try {
             // Setup and configure the connection
             connection = SaltStackRequestFactory.getInstance().initConnection(
@@ -94,7 +91,6 @@ public class SaltStackJDKConnection<T> implements SaltStackConnection<T> {
             if (connection != null) {
                 connection.disconnect();
             }
-            SaltStackClientUtils.closeQuietly(inputStream);
         }
     }
 }

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackJDKConnection.java
@@ -83,8 +83,7 @@ public class SaltStackJDKConnection<T> implements SaltStackConnection<T> {
             int responseCode = connection.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK ||
                     responseCode == HttpURLConnection.HTTP_ACCEPTED) {
-                T result = parser.parse(connection.getInputStream());
-                return result;
+                return parser.parse(connection.getInputStream());
             } else {
                 // Request was not successful
                 throw new SaltStackException("Response code: " + responseCode);

--- a/src/main/java/com/suse/saltstack/netapi/exception/SaltStackParsingException.java
+++ b/src/main/java/com/suse/saltstack/netapi/exception/SaltStackParsingException.java
@@ -1,7 +1,7 @@
 package com.suse.saltstack.netapi.exception;
 
 /**
- * Created by rolf on 2/10/15.
+ * Exception to be thrown in case of problems parsing service responses.
  */
 public class SaltStackParsingException extends SaltStackException {
     /**

--- a/src/main/java/com/suse/saltstack/netapi/parser/SaltStackParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/SaltStackParser.java
@@ -2,7 +2,6 @@ package com.suse.saltstack.netapi.parser;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.suse.saltstack.netapi.exception.SaltStackParsingException;
 import com.suse.saltstack.netapi.results.*;
 
 import java.io.BufferedReader;
@@ -45,7 +44,7 @@ public class SaltStackParser<T> {
      * @param inputStream result stream to parse.
      * @return The parsed value.
      */
-    public T parse(InputStream inputStream) throws SaltStackParsingException {
+    public T parse(InputStream inputStream) {
         Reader inputStreamReader = new InputStreamReader(inputStream);
         Reader streamReader = new BufferedReader(inputStreamReader);
 

--- a/src/main/java/com/suse/saltstack/netapi/utils/SaltStackClientUtils.java
+++ b/src/main/java/com/suse/saltstack/netapi/utils/SaltStackClientUtils.java
@@ -15,7 +15,7 @@ public class SaltStackClientUtils {
     /**
      * Quietly close a given stream, suppressing exceptions.
      *
-     * @param stream
+     * @param stream Stream to close
      */
     public static void closeQuietly(InputStream stream) {
         if (stream == null) {

--- a/src/test/java/com/suse/saltstack/netapi/config/SaltStackClientConfigTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/config/SaltStackClientConfigTest.java
@@ -14,7 +14,7 @@ public class SaltStackClientConfigTest {
 
         assertEquals("New empty config should return defaultValue", config.get(key), key.defaultValue);
 
-        Integer newValue = new Integer(123);
+        Integer newValue = 123;
         config.put(key, newValue);
         assertEquals("Should return the new configured value", config.get(key), newValue);
 

--- a/src/test/java/com/suse/saltstack/netapi/utils/SaltStackClientUtilsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/utils/SaltStackClientUtilsTest.java
@@ -36,7 +36,7 @@ public class SaltStackClientUtilsTest {
                 }
                 closed = true;
             }
-        };
+        }
 
         // Close valid stream
         MockedInputStream is = new MockedInputStream();


### PR DESCRIPTION
- Code cleanup such as removing extra semicolon, redundant or unused variables, incorrect exception throw specifications and unnecessary boxing for primitive integer type.
- Add missing Javadoc and remove incorrect ones.