### PR TITLE
Add possibility to query for job results

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/Connection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/Connection.java
@@ -8,6 +8,15 @@ import java.lang.reflect.Type;
  * Describes an interface for different HTTP connection implementations.
  */
 public interface Connection<T> {
+
+    /**
+     * Send a GET request and parse the result into object of given {@link Type}.
+     *
+     * @return object of type given by resultType
+     * @throws SaltStackException
+     */
+    T getResult() throws SaltStackException;
+
     /**
      * Send a POST request and parse the result into object of given {@link Type}.
      *

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -290,6 +290,37 @@ public class SaltStackClient {
     }
 
     /**
+     * Query for result of supplied job.
+     *
+     * GET /job/<job-id>
+     *
+     * @param job {@link Job} object representing scheduled job
+     * @return Map key: minion id, value: command result from that minion
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Map<String,Object> getJobResult(final Job job) throws SaltStackException {
+        return getJobResult(job.getJid());
+    }
+
+    /**
+     * Query for result of supplied job.
+     *
+     * GET /job/<job-id>
+     *
+     * @param job String representing scheduled job
+     * @return Map key: minion id, value: command result from that minion
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Map<String,Object> getJobResult(final String job) throws SaltStackException {
+        Result<List<Map<String,Object>>> result = connectionFactory
+                .create("/jobs/"+job, JsonParser.RETVALS, config)
+                .getResult();
+
+        // A list with one element is returned, we take the first
+        return result.getResult().get(0);
+    }
+
+    /**
      * Generic interface to start any execution command bypassing normal session handling.
      *
      * POST /run

--- a/src/main/java/com/suse/saltstack/netapi/client/impl/JDKConnection.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/impl/JDKConnection.java
@@ -45,6 +45,14 @@ public class JDKConnection<T> implements Connection<T> {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public T getResult() throws SaltStackException {
+        return request("GET", null);
+    }
+
+    /**
      * Perform HTTP request and parse the result into a given result type.
      *
      * @param method the HTTP method to use

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -213,4 +213,19 @@ public class SaltStackClientTest {
         assertEquals(job.getJid(), "20150211105524392307");
         assertEquals(job.getMinions(), Arrays.asList("myminion"));
     }
+
+    @Test
+    public void testQueryJobResult() throws SaltStackException {
+        stubFor(get(urlEqualTo("/jobs/some-job-id"))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_OK)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(JSON_RUN_RESPONSE)));
+
+        Map<String, Object> retvals = client.getJobResult("some-job-id");
+
+        assertNotNull(retvals);
+        assertTrue(retvals.containsKey("minion-1"));
+        assertEquals(retvals.get("minion-1"), true);
+    }
 }


### PR DESCRIPTION
The `startCommand()` methods return opaque job ids. These commits introduce a new client methods `queryJobResult()`, which enable querying for the results of those jobs.

The `Connection` class was extended by one method, enabling the creation of `GET` requests.