### PR TITLE
Add option fork="yes" to <junit> tag on build.xml to avoid classpath problems

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -97,7 +97,7 @@
   <!-- Run tests using built artifacts -->
   <target name="run-tests" depends="dist-tests">
     <mkdir dir="${dir-test-reports}" />
-    <junit printsummary="yes" haltonfailure="yes">
+    <junit printsummary="yes" haltonfailure="yes" fork="yes">
       <classpath refid="classpath-tests" />
       <batchtest todir="${dir-test-reports}">
           <fileset dir="${dir-src-test}">


### PR DESCRIPTION
At least on Ubuntu 14.04 when running ```ant run-tests``` the following error is printed on the test reports:

```
junit/framework/JUnit4TestAdapterCache
java.lang.NoClassDefFoundError: junit/framework/JUnit4TestAdapterCache
```

This does not happen on Ubuntu 14.10.

According to [1] and [2] it's a classpath problem. Adding ```fork="yes"``` to ```<junit>``` tag on build.xml solves the problem for both Ubuntu 14.04 and 14.10 (and probably others as well). This option tells ant to run tests on a separate JVM [3], hopefully with correct JUnit jars on classpath.

[1] https://github.com/real-logic/simple-binary-encoding/issues/96
[2] https://lists.debian.org/debian-java/2013/06/msg00086.html
[3] http://ant.apache.org/manual/Tasks/junit.html