### PR TITLE
new testStartCommandAsync() in SaltStackClientTest

### DIFF
--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -213,4 +213,24 @@ public class SaltStackClientTest {
         assertEquals(job.getJid(), "20150211105524392307");
         assertEquals(job.getMinions(), Arrays.asList("myminion"));
     }
+    
+    @Test
+    public void testStartCommandAsync() throws SaltStackException {
+    	 stubFor(post(urlEqualTo("/minions")).willReturn(
+                 aResponse().withStatus(HttpURLConnection.HTTP_OK)
+                         .withHeader("Content-Type", "application/json")
+                         .withBody(JSON_START_COMMAND_RESPONSE)));
+
+        Future<Job> future = client.startCommandAsync("*", "test.ping", null, null);
+        Job job;
+        try {
+        	job = future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new SaltStackException(e);
+        }
+
+        assertNotNull(job);
+        assertEquals(job.getJid(), "20150211105524392307");
+        assertEquals(job.getMinions(), Arrays.asList("myminion"));
+    }
 }


### PR DESCRIPTION
new testStartCommandAsync() in SaltStackClientTest. it tests SaltStackClient.startCommandAsync().

the mockup result json used for the test is copied from /test/resources/minions_response.json, like other json results are embedded into the SaltStackClientTest as String.
this json seems valid, a 'salt-api 2015.2.0rc1' returns the same result structure.

it's the async pair of the testStartCommand() in SaltStackClientTest, using the same input datas, doing the same checks.