### PR TITLE
/stats endpoint implementation

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -5,6 +5,7 @@ import com.suse.saltstack.netapi.client.impl.HttpClientConnectionFactory;
 import com.suse.saltstack.netapi.config.ClientConfig;
 import static com.suse.saltstack.netapi.config.ClientConfig.*;
 import com.suse.saltstack.netapi.config.ProxySettings;
+import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
 import com.suse.saltstack.netapi.datatypes.Job;
@@ -385,4 +386,33 @@ public class SaltStackClient {
         };
         return executor.submit(callable);
     }
+
+  /**
+  * Query statistics from the CherryPy Server.
+  *
+  * GET /stats
+  *
+  * @return The {@link Stats} object.
+  * @throws SaltStackException if anything goes wrong
+  */
+  public Stats stats() throws SaltStackException {
+      return connectionFactory.create("/stats", JsonParser.STATS, config).getResult();
+  }
+
+  /**
+  * Asynchronously query statistics from the CherryPy Server.
+  *
+  * GET /stats
+  *
+  * @return Future containing the {@link Stats} object.
+  */
+  public Future<Stats> statsAsync() {
+      Callable<Stats> callable = new Callable<Stats>() {
+          @Override
+          public Stats call() throws SaltStackException {
+              return stats();
+          }
+      };
+      return executor.submit(callable);
+  }
 }

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Applications.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Applications.java
@@ -1,0 +1,121 @@
+package com.suse.saltstack.netapi.datatypes.cherrypy;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+import java.util.Map;
+
+public class Applications {
+
+    @SerializedName("Uptime")
+    private double uptime;
+
+    @SerializedName("Bytes Read/Second")
+    private double readsPerSecond;
+
+    @SerializedName("Current Time")
+    private Date currentTime;
+
+    @SerializedName("Server Version")
+    private String serverVersion;
+
+    @SerializedName("Total Time")
+    private double totalTime;
+
+    @SerializedName("Enabled")
+    private boolean enabled;
+
+    @SerializedName("Start Time")
+    private Date startTime;
+
+    @SerializedName("Bytes Written/Second")
+    private double writesPerSecond;
+
+    @SerializedName("Total Bytes Read")
+    private int totalBytesRead;
+
+    @SerializedName("Current Requests")
+    private int currentRequests;
+
+    @SerializedName("Total Requests")
+    private int totalRequests;
+
+    @SerializedName("Requests")
+    Map<String, Request> requests;
+
+    @SerializedName("Bytes Read/Request")
+    private double readsPerRequest;
+
+    @SerializedName("Total Bytes Written")
+    private int totalBytesWritten;
+
+    @SerializedName("Requests/Second")
+    private double requestsPerSecond;
+
+    @SerializedName("Bytes Written/Request")
+    private double writesPerRequest;
+
+    public double getUptime() {
+        return uptime;
+    }
+
+    public double getReadsPerSecond() {
+        return readsPerSecond;
+    }
+
+    public Date getCurrentTime() {
+        return currentTime;
+    }
+
+    public String getServerVersion() {
+        return serverVersion;
+    }
+
+    public double getTotalTime() {
+        return totalTime;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public double getWritesPerSecond() {
+        return writesPerSecond;
+    }
+
+    public int getTotalBytesRead() {
+        return totalBytesRead;
+    }
+
+    public int getCurrentRequests() {
+        return currentRequests;
+    }
+
+    public int getTotalRequests() {
+        return totalRequests;
+    }
+
+    public Map<String, Request> getRequests() {
+        return requests;
+    }
+
+    public double getReadsPerRequest() {
+        return readsPerRequest;
+    }
+
+    public int getTotalBytesWritten() {
+        return totalBytesWritten;
+    }
+
+    public double getRequestsPerSecond() {
+        return requestsPerSecond;
+    }
+
+    public double getWritesPerRequest() {
+        return writesPerRequest;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/HttpServer.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/HttpServer.java
@@ -1,0 +1,120 @@
+package com.suse.saltstack.netapi.datatypes.cherrypy;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+public class HttpServer {
+
+    @SerializedName("Bytes Read")
+    private int bytesRead;
+
+    @SerializedName("Accepts/sec")
+    private double acceptsPerSecond;
+
+    @SerializedName("Socket Errors")
+    private int socketErrors;
+
+    @SerializedName("Accepts")
+    private int accepts;
+
+    @SerializedName("Threads Idle")
+    private int threadsIdle;
+
+    @SerializedName("Enabled")
+    private boolean enable;
+
+    @SerializedName("Bind Address")
+    private String bindAddress;
+
+    @SerializedName("Read Throughput")
+    private int readThroughput;
+
+    @SerializedName("Queue")
+    private int queue;
+
+    @SerializedName("Run time")
+    private int runTime;
+
+    @SerializedName("Worker Threads")
+    private Map<String, ServerThread> workerThreads;
+
+    @SerializedName("Threads")
+    private int threads;
+
+    @SerializedName("Bytes Written")
+    private int bytesWritten;
+
+    @SerializedName("Requests")
+    private int requests;
+
+    @SerializedName("Work Time")
+    private int workTime;
+
+    @SerializedName("Write Throughput")
+    private double writeThroughput;
+
+    public int getBytesRead() {
+        return bytesRead;
+    }
+
+    public double getAcceptsPerSecond() {
+        return acceptsPerSecond;
+    }
+
+    public int getSocketErrors() {
+        return socketErrors;
+    }
+
+    public int getAccepts() {
+        return accepts;
+    }
+
+    public int getThreadsIdle() {
+        return threadsIdle;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public String getBindAddress() {
+        return bindAddress;
+    }
+
+    public int getReadThroughput() {
+        return readThroughput;
+    }
+
+    public int getQueue() {
+        return queue;
+    }
+
+    public int getRunTime() {
+        return runTime;
+    }
+
+    public Map<String, ServerThread> getWorkerThreads() {
+        return workerThreads;
+    }
+
+    public int getThreads() {
+        return threads;
+    }
+
+    public int getBytesWritten() {
+        return bytesWritten;
+    }
+
+    public int getRequests() {
+        return requests;
+    }
+
+    public int getWorkTime() {
+        return workTime;
+    }
+
+    public double getWriteThroughput() {
+        return writeThroughput;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Request.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Request.java
@@ -1,0 +1,64 @@
+package com.suse.saltstack.netapi.datatypes.cherrypy;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
+public class Request {
+
+    @SerializedName("Bytes Read")
+    private Integer bytesRead;
+
+    @SerializedName("Bytes Written")
+    private Integer bytesWritten;
+
+    @SerializedName("Response Status")
+    private String responeStatus;
+
+    @SerializedName("Start Time")
+    private Date startTime;
+
+    @SerializedName("End Time")
+    private Date endTime;
+
+    @SerializedName("Client")
+    private String client;
+
+    @SerializedName("Processing Time")
+    private double processingTime;
+
+    @SerializedName("Request-Line")
+    private String requestLine;
+
+    public Integer getBytesRead() {
+        return bytesRead;
+    }
+
+    public Integer getBytesWritten() {
+        return bytesWritten;
+    }
+
+    public String getResponeStatus() {
+        return responeStatus;
+    }
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public double getProcessingTime() {
+        return processingTime;
+    }
+
+    public String getRequestLine() {
+        return requestLine;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/ServerThread.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/ServerThread.java
@@ -1,0 +1,48 @@
+package com.suse.saltstack.netapi.datatypes.cherrypy;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ServerThread {
+
+    @SerializedName("Bytes Read")
+    private int bytesRead;
+
+    @SerializedName("Bytes Written")
+    private int bytesWritten;
+
+    @SerializedName("Read Throughput")
+    private double readThroughput;
+
+    @SerializedName("Requests")
+    private int requests;
+
+    @SerializedName("Work Time")
+    private double workTime;
+
+    @SerializedName("Write Throughput")
+    private double writeThroughput;
+
+    public double getWriteThroughput() {
+        return writeThroughput;
+    }
+
+    public int getBytesRead() {
+        return bytesRead;
+    }
+
+    public int getBytesWritten() {
+        return bytesWritten;
+    }
+
+    public double getReadThroughput() {
+        return readThroughput;
+    }
+
+    public int getRequests() {
+        return requests;
+    }
+
+    public double getWorkTime() {
+        return workTime;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Stats.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/cherrypy/Stats.java
@@ -1,0 +1,24 @@
+package com.suse.saltstack.netapi.datatypes.cherrypy;
+
+public class Stats {
+
+    private final Applications applications;
+    private final HttpServer httpServer;
+
+    public Stats(Applications applications, HttpServer httpServer)
+            throws IllegalArgumentException {
+        if (applications == null || httpServer == null) {
+            throw new IllegalArgumentException("applications and httpServer must not be null");
+        }
+        this.applications = applications;
+        this.httpServer = httpServer;
+    }
+
+    public Applications getApplications() {
+        return applications;
+    }
+
+    public HttpServer getHttpServer() {
+        return httpServer;
+    }
+}

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -1,5 +1,6 @@
 package com.suse.saltstack.netapi.client;
 
+import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.Token;
@@ -39,6 +40,8 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/run_request.json"));
     static final String JSON_RUN_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/run_response.json"));
+    static final String JSON_STATS_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream("/stats_response.json"));
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -221,5 +224,37 @@ public class SaltStackClientTest {
         assertNotNull(job);
         assertEquals(job.getJid(), "20150211105524392307");
         assertEquals(job.getMinions(), Arrays.asList("myminion"));
+    }
+
+    @Test
+    public void testStats() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_OK)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(JSON_STATS_RESPONSE)));
+
+        Stats stats = client.stats();
+
+        assertNotNull(stats);
+        verify(1, getRequestedFor(urlEqualTo("/stats"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testStatsAsync() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_OK)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(JSON_STATS_RESPONSE)));
+
+        Stats stats = client.statsAsync().get();
+
+        assertNotNull(stats);
+        verify(1, getRequestedFor(urlEqualTo("/stats"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
     }
 }

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -2,6 +2,7 @@ package com.suse.saltstack.netapi.parser;
 
 import com.google.gson.JsonParseException;
 import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.cherrypy.*;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.datatypes.Token;
 import java.util.Date;
@@ -46,5 +47,78 @@ public class JsonParserTest {
     public void testSaltStackTokenParserWrongDate() throws Exception {
         InputStream is = this.getClass().getResourceAsStream("/login_response_wrong_date.json");
         JsonParser.TOKEN.parse(is);
+    }
+
+    @Test
+    public void testStatsParser() throws Exception {
+        InputStream is = this.getClass().getResourceAsStream("/stats_response.json");
+        Stats result = JsonParser.STATS.parse(is);
+        assertNotNull(result);
+
+        Applications applications = result.getApplications();
+        assertNotNull(applications);
+        assertEquals(47.72178888320923, applications.getUptime(), 0);
+        assertEquals(1.1315585135535497, applications.getReadsPerSecond(), 0);
+        assertEquals(new Date(1425821785119L), applications.getCurrentTime());
+        assertEquals("3.6.0", applications.getServerVersion());
+        assertEquals(0.06533312797546387, applications.getTotalTime(), 0);
+        assertEquals(true, applications.isEnabled());
+        assertEquals(new Date(1425821737397L), applications.getStartTime());
+        assertEquals(3.918541522794187, applications.getWritesPerSecond(), 0);
+        assertEquals(54, applications.getTotalBytesRead());
+        assertEquals(1, applications.getCurrentRequests());
+        assertEquals(2, applications.getTotalRequests());
+        assertEquals(27.0, applications.getReadsPerRequest(), 0);
+        assertEquals(187, applications.getTotalBytesWritten());
+        assertEquals(0.04190954295959868, applications.getRequestsPerSecond(), 0);
+        assertEquals(93.5, applications.getWritesPerRequest(), 0);
+
+        Request req1 = applications.getRequests().get("140691837540096");
+        assertEquals(new Integer(54), req1.getBytesRead());
+        assertEquals(new Integer(187), req1.getBytesWritten());
+        assertEquals("200 OK", req1.getResponeStatus());
+        assertEquals(new Date(1425821772580L), req1.getStartTime());
+        assertEquals(new Date(1425821772645L), req1.getEndTime());
+        assertEquals("127.0.0.1:45009", req1.getClient());
+        assertEquals(0.06533312797546387, req1.getProcessingTime(), 0);
+        assertEquals("POST /login HTTP/1.1", req1.getRequestLine());
+
+        Request req2 = applications.getRequests().get("140691829147392");
+        assertEquals(null, req2.getBytesRead());
+        assertEquals(null, req2.getBytesWritten());
+        assertEquals(null, req2.getResponeStatus());
+        assertEquals(new Date(1425821785119L), req2.getStartTime());
+        assertEquals(null, req2.getEndTime());
+        assertEquals("127.0.0.1:45015", req2.getClient());
+        assertEquals(0.0002930164337158203, req2.getProcessingTime(), 0);
+        assertEquals("GET /stats HTTP/1.1", req2.getRequestLine());
+
+        HttpServer server = result.getHttpServer();
+        assertNotNull(server);
+        assertEquals(-1, server.getBytesRead());
+        assertEquals(0.0, server.getAcceptsPerSecond(), 0);
+        assertEquals(2, server.getSocketErrors());
+        assertEquals(3, server.getAccepts());
+        assertEquals(99, server.getThreadsIdle());
+        assertEquals(false, server.isEnable());
+        assertEquals("('0.0.0.0', 8000)", server.getBindAddress());
+        assertEquals(4, server.getReadThroughput());
+        assertEquals(5, server.getQueue());
+        assertEquals(6, server.getRunTime());
+        assertEquals(3, server.getThreads());
+        assertEquals(7, server.getBytesWritten());
+        assertEquals(8, server.getRequests());
+        assertEquals(9.0, server.getWorkTime(), 0);
+        assertEquals(10, server.getWriteThroughput(), 0);
+
+        for (int i = 0; i < server.getThreads(); i++) {
+            ServerThread thread = server.getWorkerThreads().get("CP Server Thread-"+i);
+            assertEquals(0, thread.getBytesRead());
+            assertEquals(2, thread.getBytesWritten());
+            assertEquals(3.4, thread.getReadThroughput(), 0);
+            assertEquals(5, thread.getRequests());
+            assertEquals(6, thread.getWorkTime(), 0);
+            assertEquals(7.8, thread.getWriteThroughput(), 0);
+        }
     }
 }

--- a/src/test/resources/stats_response.json
+++ b/src/test/resources/stats_response.json
@@ -1,0 +1,84 @@
+{
+  "CherryPy Applications": {
+    "Uptime": 47.72178888320923,
+    "Bytes Read/Second": 1.1315585135535497,
+    "Current Time": 1425821785.119284,
+    "Server Version": "3.6.0",
+    "Total Time": 0.06533312797546387,
+    "Enabled": true,
+    "Start Time": 1425821737.39749,
+    "Bytes Written/Second": 3.918541522794187,
+    "Total Bytes Read": 54,
+    "Current Requests": 1,
+    "Total Requests": 2,
+    "Requests": {
+      "140691837540096": {
+        "Bytes Read": 54,
+        "Bytes Written": 187,
+        "Response Status": "200 OK",
+        "Start Time": 1425821772.58038,
+        "End Time": 1425821772.645713,
+        "Client": "127.0.0.1:45009",
+        "Processing Time": 0.06533312797546387,
+        "Request-Line": "POST /login HTTP/1.1"
+      },
+      "140691829147392": {
+        "Bytes Read": null,
+        "Bytes Written": null,
+        "Response Status": null,
+        "Start Time": 1425821785.119022,
+        "End Time": null,
+        "Client": "127.0.0.1:45015",
+        "Processing Time": 0.0002930164337158203,
+        "Request-Line": "GET /stats HTTP/1.1"
+      }
+    },
+    "Bytes Read/Request": 27.0,
+    "Total Bytes Written": 187,
+    "Requests/Second": 0.04190954295959868,
+    "Bytes Written/Request": 93.5
+  },
+  "CherryPy HTTPServer 140575992016208": {
+    "Bytes Read": -1,
+    "Accepts/sec": 0.0,
+    "Socket Errors": 2,
+    "Accepts": 3,
+    "Threads Idle": 99,
+    "Enabled": false,
+    "Bind Address": "('0.0.0.0', 8000)",
+    "Read Throughput": 4,
+    "Queue": 5,
+    "Run time": 6,
+    "Worker Threads": {
+      "CP Server Thread-0": {
+        "Bytes Read": 0,
+        "Bytes Written": 2,
+        "Read Throughput": 3.4,
+        "Requests": 5,
+        "Work Time": 6,
+        "Write Throughput": 7.8
+      },
+      "CP Server Thread-1": {
+        "Bytes Read": 0,
+        "Bytes Written": 2,
+        "Read Throughput": 3.4,
+        "Requests": 5,
+        "Work Time": 6,
+        "Write Throughput": 7.8
+      },
+      "CP Server Thread-2": {
+        "Bytes Read": 0,
+        "Bytes Written": 2,
+        "Read Throughput": 3.4,
+        "Requests": 5,
+        "Work Time": 6,
+        "Write Throughput": 7.8
+      }
+    },
+    "Threads": 3,
+    "Bytes Written": 7,
+    "Requests": 8,
+    "Work Time": 9.0,
+    "Write Throughput": 10
+  }
+}


### PR DESCRIPTION
This PR implements access to the netapi `/stats` endpoint. I couldn't find any documentation on the return type of this call so all the datatypes are "best guess" implementations based on the `json` returned by my local saltmaster. I also left the `Request` field of `cherrypy.Applications` unimplemented and added a todo since the `json` only contains an empty object so i don't know it's structure.



#### Aditional thoughts / Improvements

* `getBindAddress` could return `InetSocketAddress` instead of a `String`
* Exposing `getThreads` feels redundant since `getWorkerThreads().size()` should give the same information.
* `Uptime` could be represented with `java.time.Duration` when we move to Java 8.
* Redundant information like in `threads` /  `workerThreads` and `uptime` / `startTime` / `currentTime` could be checked against each other for validation to filter some "bad" responses.