### PR TITLE
Add support for querrying jobs

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -8,7 +8,7 @@ import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
-import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.datatypes.Token;
 
@@ -192,7 +192,8 @@ public class SaltStackClient {
     }
 
     /**
-     * Generic interface to start any execution command and immediately return the job id.
+     * Generic interface to start any execution command and immediately return an object
+     * representing the scheduled job.
      *
      * POST /minions
      *
@@ -203,8 +204,8 @@ public class SaltStackClient {
      * @return object representing the scheduled job
      * @throws SaltStackException if anything goes wrong
      */
-    public Job startCommand(final String target, final String function, List<String> args,
-            Map<String, String> kwargs) throws SaltStackException {
+    public JobMinions startCommand(final String target, final String function,
+            List<String> args, Map<String, String> kwargs) throws SaltStackException {
         Map<String, String> props = new LinkedHashMap<String, String>() {
             {
                 put("tgt", target);
@@ -216,8 +217,8 @@ public class SaltStackClient {
         jsonArray.add(ClientUtils.makeJsonData(props, kwargs, args));
 
         // Connect to the minions endpoint and send the above lowstate data
-        Result<List<Job>> result = connectionFactory
-                .create("/minions", JsonParser.JOB,  config)
+        Result<List<JobMinions>> result = connectionFactory
+                .create("/minions", JsonParser.JOB_MINIONS,  config)
                 .getResult(jsonArray.toString());
 
         // They return a list of tokens here, we take the first
@@ -225,7 +226,8 @@ public class SaltStackClient {
     }
 
     /**
-     * Asynchronously start any execution command and immediately return the job id
+     * Asynchronously start any execution command and immediately return an object
+     * representing the scheduled job.
      *
      * POST /minions
      *
@@ -233,13 +235,13 @@ public class SaltStackClient {
      * @param function the function to execute
      * @param args list of non-keyword arguments
      * @param kwargs map containing keyword arguments
-     * @return Future containing the scheduled job {@link Job}
+     * @return Future containing the scheduled job {@link JobMinions}
      */
-    public Future<Job> startCommandAsync(final String target, final String function,
+    public Future<JobMinions> startCommandAsync(final String target, final String function,
             final List<String> args, final Map<String, String> kwargs) {
-        Callable<Job> callable = new Callable<Job>() {
+        Callable<JobMinions> callable = new Callable<JobMinions>() {
             @Override
-            public Job call() throws SaltStackException {
+            public JobMinions call() throws SaltStackException {
                 return startCommand(target, function, args, kwargs);
             }
         };
@@ -251,11 +253,12 @@ public class SaltStackClient {
      *
      * GET /job/<job-id>
      *
-     * @param job {@link Job} object representing scheduled job
+     * @param job {@link JobMinions} object representing scheduled job
      * @return Map key: minion id, value: command result from that minion
      * @throws SaltStackException if anything goes wrong
      */
-    public Map<String, Object> getJobResult(final Job job) throws SaltStackException {
+    public Map<String, Object> getJobResult(final JobMinions job)
+            throws SaltStackException {
         return getJobResult(job.getJid());
     }
 

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -8,6 +8,7 @@ import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
+import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.datatypes.Token;
@@ -278,6 +279,32 @@ public class SaltStackClient {
 
         // A list with one element is returned, we take the first
         return result.getResult().get(0);
+    }
+
+    /**
+     * Get previously run jobs.
+     * @return map containing run jobs keyed by job id.
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Map<String, Job> getJobs() throws SaltStackException {
+        Result<List<Map<String, Job>>> result = connectionFactory
+                .create("/jobs", JsonParser.JOBS, config)
+                .getResult();
+        return result.getResult().get(0);
+    }
+
+    /**
+     * Get previously run jobs.
+     * @return future with a map containing run jobs keyed by job id.
+     */
+    public Future<Map<String, Job>> getJobsAsync() {
+        Callable<Map<String, Job>> callable = new Callable<Map<String, Job>>() {
+            @Override
+            public Map<String, Job> call() throws SaltStackException {
+                return getJobs();
+            }
+        };
+        return executor.submit(callable);
     }
 
     /**

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Arguments.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Arguments.java
@@ -1,0 +1,36 @@
+package com.suse.saltstack.netapi.datatypes;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of args and kwargs.
+ */
+public class Arguments {
+
+    private List<Object> args;
+    private Map<String, Object> kwargs;
+
+    public Arguments() {
+        args = new ArrayList<>();
+        kwargs = new LinkedHashMap<>();
+    }
+
+    public List<Object> getArgs() {
+        return args;
+    }
+
+    public Map<String, Object> getKwargs() {
+        return kwargs;
+    }
+
+    @Override
+    public String toString() {
+        return "Arguments{" +
+                "args=" + args +
+                ", kwargs=" + kwargs +
+                '}';
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
@@ -1,0 +1,47 @@
+package com.suse.saltstack.netapi.datatypes;
+
+import com.google.gson.annotations.SerializedName;
+
+// TODO - handle dates too (they are represented in really
+// exotic format: (2015, Mar 04 19:28:29.724698))
+
+/**
+ * Representation of a previously run job.
+ */
+public class Job {
+
+    @SerializedName("Function")
+    private String function;
+
+    @SerializedName("Target")
+    private String target;
+
+    @SerializedName("Target-type")
+    private String targetType;
+
+    @SerializedName("User")
+    private String user;
+
+    @SerializedName("Arguments")
+    private Arguments arguments;
+
+    public String getFunction() {
+        return function;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getTargetType() {
+        return targetType;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Arguments getArguments() {
+        return arguments;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/JobMinions.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/JobMinions.java
@@ -3,9 +3,9 @@ package com.suse.saltstack.netapi.datatypes;
 import java.util.List;
 
 /**
- * Representation of a list of minions associated with given job.
+ * Representation of a scheduled job and a list of minions associated with it.
  */
-public class Job {
+public class JobMinions {
 
     private String jid;
     private List<String> minions;

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
-import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
@@ -36,8 +36,8 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<String>>(){});
     public static final JsonParser<Result<List<Token>>> TOKEN =
             new JsonParser<>(new TypeToken<Result<List<Token>>>(){});
-    public static final JsonParser<Result<List<Job>>> JOB =
-            new JsonParser<>(new TypeToken<Result<List<Job>>>(){});
+    public static final JsonParser<Result<List<JobMinions>>> JOB_MINIONS =
+            new JsonParser<>(new TypeToken<Result<List<JobMinions>>>(){});
     public static final JsonParser<Result<List<Map<String, Object>>>> RETVALS =
             new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Stats> STATS =

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -8,6 +8,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
+import com.suse.saltstack.netapi.datatypes.Arguments;
+import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.Token;
@@ -38,6 +40,8 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<List<Token>>>(){});
     public static final JsonParser<Result<List<JobMinions>>> JOB_MINIONS =
             new JsonParser<>(new TypeToken<Result<List<JobMinions>>>(){});
+    public static final JsonParser<Result<List<Map<String, Job>>>> JOBS =
+            new JsonParser<>(new TypeToken<Result<List<Map<String, Job>>>>(){});
     public static final JsonParser<Result<List<Map<String, Object>>>> RETVALS =
             new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Stats> STATS =
@@ -58,6 +62,7 @@ public class JsonParser<T> {
         this.gson = new GsonBuilder()
                 .registerTypeAdapter(Date.class, new SaltStackDateDeserializer())
                 .registerTypeAdapter(Stats.class, new StatsDeserializer())
+                .registerTypeAdapter(Arguments.class, new ArgumentsDeserializer())
                 .create();
     }
 
@@ -119,6 +124,91 @@ public class JsonParser<T> {
                 return new Stats(app, server);
             } catch (Exception e) {
                 throw new JsonParseException(e);
+            }
+        }
+    }
+
+    /**
+     * Deserializer for Arguments class.
+     * Breaks the incoming arguments into args and kwargs parts
+     * and fills a new Arguments instance.
+     */
+    private class ArgumentsDeserializer implements JsonDeserializer<Arguments> {
+
+        private static final String KWARG_KEY = "__kwarg__";
+
+        @Override
+        public Arguments deserialize(JsonElement json, Type typeOfT,
+                JsonDeserializationContext context) throws JsonParseException {
+            Arguments result = new Arguments();
+
+            if (json != null && json.isJsonArray()) {
+                for (JsonElement jsonElement : json.getAsJsonArray()) {
+                    fillArgs(result, jsonElement);
+                }
+            }
+
+            return result;
+        }
+
+        /**
+         * Fills args/kwargs to given Arguments instance based on JSON data
+         * from jsonElement.
+         *
+         * @param result Arguments to be filled
+         * @param jsonElement input JSON data
+         */
+        private void fillArgs(Arguments result, JsonElement jsonElement) {
+            if (isKwarg(jsonElement)) {
+                filterKwarg(jsonElement);
+                fillKwargsFromObject(result, jsonElement.getAsJsonObject());
+            } else {
+                result.getArgs().add(gson.fromJson(jsonElement, Object.class));
+            }
+        }
+
+        /**
+         * Fills kwargs from given jsonObject key/values to given Arguments instance.
+         *
+         * @param result Arguments to be filled
+         * @param jsonObject input json data
+         */
+        private void fillKwargsFromObject(Arguments result, JsonObject jsonObject) {
+            for (Map.Entry<String, JsonElement> kwItem : jsonObject.entrySet()) {
+                result.getKwargs().put(kwItem.getKey(),
+                        gson.fromJson(kwItem.getValue(),
+                        Object.class));
+            }
+        }
+
+        /**
+         * Checks whether element is kwarg or arg.
+         * Element is a kwarg if it's an object and contains __kwarg__ property set to true.
+         *
+         * @param jsonElement element to be tested
+         * @return true if element is kwarg
+         */
+        private boolean isKwarg(JsonElement jsonElement) {
+            if (!jsonElement.isJsonObject()) {
+                return false;
+            }
+
+            JsonElement kwarg = jsonElement.getAsJsonObject().get(KWARG_KEY);
+            return kwarg != null
+                    && kwarg.isJsonPrimitive()
+                    && kwarg.getAsJsonPrimitive().isBoolean()
+                    && kwarg.getAsBoolean();
+        }
+
+        /**
+         * Filters __kwarg__ flag from given element.
+         *
+         * @param jsonElement
+         */
+        private void filterKwarg(JsonElement jsonElement) {
+            if (jsonElement.isJsonObject()
+                    && jsonElement.getAsJsonObject().has(KWARG_KEY)) {
+                jsonElement.getAsJsonObject().remove(KWARG_KEY);
             }
         }
     }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -1,5 +1,6 @@
 package com.suse.saltstack.netapi.client;
 
+import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.client.impl.JDKConnectionFactory;
@@ -71,6 +72,8 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/stats_response.json"));
     static final String JSON_KEYS_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/keys_response.json"));
+    static final String JSON_JOBS_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream("/jobs_response.json"));
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -416,4 +419,41 @@ public class SaltStackClientTest {
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));
     }
+
+    @Test
+    public void testJobs() throws Exception {
+        stubFor(get(urlMatching("/jobs"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_RESPONSE)));
+
+        Map<String, Job> jobs = client.getJobs();
+
+        assertNotNull(jobs);
+        assertEquals(Arrays.asList("enable-autodestruction"),
+                jobs.get("20150304200110485012").getArguments().getArgs());
+        verify(1, getRequestedFor(urlEqualTo("/jobs"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testJobsAsync() throws Exception {
+        stubFor(get(urlMatching("/jobs"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_RESPONSE)));
+
+        Map<String, Job> jobs = client.getJobsAsync().get();
+
+        assertNotNull(jobs);
+        assertEquals(Arrays.asList("enable-autodestruction"),
+                jobs.get("20150304200110485012").getArguments().getArgs());
+        verify(1, getRequestedFor(urlEqualTo("/jobs"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
 }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -3,7 +3,7 @@ package com.suse.saltstack.netapi.client;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.client.impl.JDKConnectionFactory;
-import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.utils.ClientUtils;
@@ -295,16 +295,16 @@ public class SaltStackClientTest {
             }
         };
 
-        Job job = client.startCommand("*", "pkg.install", args, kwargs);
+        JobMinions jobMinions = client.startCommand("*", "pkg.install", args, kwargs);
 
         verify(1, postRequestedFor(urlEqualTo("/minions"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json"))
                 .withRequestBody(equalToJson(JSON_START_COMMAND_REQUEST)));
 
-        assertNotNull(job);
-        assertEquals(job.getJid(), "20150211105524392307");
-        assertEquals(job.getMinions(), Arrays.asList("myminion"));
+        assertNotNull(jobMinions);
+        assertEquals(jobMinions.getJid(), "20150211105524392307");
+        assertEquals(jobMinions.getMinions(), Arrays.asList("myminion"));
     }
 
     @Test
@@ -339,17 +339,18 @@ public class SaltStackClientTest {
             }
         };
 
-        Future<Job> future = client.startCommandAsync("*", "pkg.install", args, kwargs);
-        Job job = future.get();
+        Future<JobMinions> future = client.startCommandAsync("*", "pkg.install", args,
+                kwargs);
+        JobMinions jobMinions = future.get();
 
         verify(1, postRequestedFor(urlEqualTo("/minions"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json"))
                 .withRequestBody(equalToJson(JSON_START_COMMAND_REQUEST)));
 
-        assertNotNull(job);
-        assertEquals(job.getJid(), "20150211105524392307");
-        assertEquals(job.getMinions(), Arrays.asList("myminion"));
+        assertNotNull(jobMinions);
+        assertEquals(jobMinions.getJid(), "20150211105524392307");
+        assertEquals(jobMinions.getMinions(), Arrays.asList("myminion"));
     }
 
     @Test

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -1,7 +1,7 @@
 package com.suse.saltstack.netapi.parser;
 
 import com.google.gson.JsonParseException;
-import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.JobMinions;
 import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
 import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
@@ -28,7 +28,7 @@ public class JsonParserTest {
     @Test
     public void testSaltStackJobParser() throws Exception {
         InputStream is = getClass().getResourceAsStream("/minions_response.json");
-        Result<List<Job>> result = JsonParser.JOB.parse(is);
+        Result<List<JobMinions>> result = JsonParser.JOB_MINIONS.parse(is);
         assertNotNull("failed to parse", result);
         String jid = result.getResult().get(0).getJid();
         assertEquals("unable to parse jid", "20150211105524392307", jid);

--- a/src/test/resources/jobs_response.json
+++ b/src/test/resources/jobs_response.json
@@ -1,0 +1,24 @@
+{
+  "return": [
+    {
+      "20150304192951636258": {
+        "Arguments": [],
+        "Function": "test.ping",
+        "StartTime": "2015, Mar 04 19:29:51.636258",
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      },
+      "20150304200110485012": {
+        "Arguments": [
+          "enable-autodestruction"
+        ],
+        "Function": "test.echo",
+        "StartTime": "2015, Mar 04 20:01:10.485012",
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      }
+    }
+  ]
+}

--- a/src/test/resources/jobs_response_args_as_kwargs.json
+++ b/src/test/resources/jobs_response_args_as_kwargs.json
@@ -1,0 +1,35 @@
+{
+  "return": [
+    {
+      "20150315163041425361": {
+        "Function": "pkg.install",
+        "Target": "*",
+        "Target-type": "glob",
+        "Arguments": [
+          {
+            "refresh": true
+          },
+          {
+            "somepar": 123.3,
+            "__kwarg__": false
+          },
+          {
+            "nullparam": null,
+            "__kwarg__": null
+          },
+          {
+            "otherparam": true,
+            "__kwarg__": 123
+          },
+          {
+            "sysupgrade": true,
+            "__kwarg__": true
+          },
+          "i3"
+        ],
+        "StartTime": "2015, Mar 15 16:30:41.425361",
+        "User": "lucid"
+      }
+    }
+  ]
+}

--- a/src/test/resources/jobs_response_kwargs.json
+++ b/src/test/resources/jobs_response_kwargs.json
@@ -1,0 +1,22 @@
+{
+  "return": [
+    {
+      "20150306023815935637": {
+        "Function": "pkg.install",
+        "Target": "*",
+        "Target-type": "glob",
+        "Arguments": [
+          "i3",
+          true,
+          {
+            "sysupgrade": true,
+            "otherkwarg": 42.5,
+            "__kwarg__": true
+          }
+        ],
+        "StartTime": "2015, Mar 06 02:38:15.935637",
+        "User": "lucid"
+      }
+    }
+  ]
+}

--- a/src/test/resources/jobs_response_multiple_kwarg.json
+++ b/src/test/resources/jobs_response_multiple_kwarg.json
@@ -1,0 +1,23 @@
+{
+  "return": [
+    {
+      "20150306023815935637": {
+        "Function": "pkg.install",
+        "Target": "*",
+        "Target-type": "glob",
+        "Arguments": [
+          {
+            "multi": true,
+            "__kwarg__": true
+          },
+          {
+            "multi": false,
+            "__kwarg__": true
+          }
+        ],
+        "StartTime": "2015, Mar 06 02:38:15.935637",
+        "User": "lucid"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
...by parsing responses to GET request on '/jobs' resource.

- The 'Job' datatype was renamed to more meaningful 'JobMinions'
  datatype.
- New datatype 'Job' was created into which the '/jobs' resource is
  parsed.
- Added corresponding parser and parser test.