### PR TITLE
Fix: send kwargs properly to the netapi and adjust tests

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -136,7 +136,7 @@ public class SaltStackClient {
      */
     public Token login(final String username, final String password, final String eauth)
             throws SaltStackException {
-        Map<String, String> kwargs = new LinkedHashMap<String, String>() {
+        Map<String, String> props = new LinkedHashMap<String, String>() {
             {
                 put("username", username);
                 put("password", password);
@@ -145,7 +145,7 @@ public class SaltStackClient {
         };
         Result<List<Token>> result = connectionFactory
                 .create("/login", JsonParser.TOKEN, config)
-                .getResult(ClientUtils.makeJsonData(kwargs, null).toString());
+                .getResult(ClientUtils.makeJsonData(props, null, null).toString());
 
         // For whatever reason they return a list of tokens here, take the first
         Token token = result.getResult().get(0);
@@ -238,18 +238,15 @@ public class SaltStackClient {
      */
     public Job startCommand(final String target, final String function, List<String> args,
             Map<String, String> kwargs) throws SaltStackException {
-        Map<String, String> allKwargs = new LinkedHashMap<String, String>() {
+        Map<String, String> props = new LinkedHashMap<String, String>() {
             {
                 put("tgt", target);
                 put("fun", function);
             }
         };
-        if (kwargs != null) {
-            allKwargs.putAll(kwargs);
-        }
 
         JsonArray jsonArray = new JsonArray();
-        jsonArray.add(ClientUtils.makeJsonData(allKwargs, args));
+        jsonArray.add(ClientUtils.makeJsonData(props, kwargs, args));
 
         // Connect to the minions endpoint and send the above lowstate data
         Result<List<Job>> result = connectionFactory
@@ -333,7 +330,7 @@ public class SaltStackClient {
             final String eauth, final String client, final String target,
             final String function, List<String> args, Map<String, String> kwargs)
             throws SaltStackException {
-        Map<String, String> allKwargs = new LinkedHashMap<String, String>() {
+        Map<String, String> props = new LinkedHashMap<String, String>() {
             {
                 put("username", username);
                 put("password", password);
@@ -343,11 +340,9 @@ public class SaltStackClient {
                 put("fun", function);
             }
         };
-        if (kwargs != null) {
-            allKwargs.putAll(kwargs);
-        }
+
         JsonArray jsonArray = new JsonArray();
-        jsonArray.add(ClientUtils.makeJsonData(allKwargs, args));
+        jsonArray.add(ClientUtils.makeJsonData(props, kwargs, args));
 
         Result<List<Map<String, Object>>> result = connectionFactory
                 .create("/run", JsonParser.RETVALS, config)

--- a/src/main/java/com/suse/saltstack/netapi/utils/ClientUtils.java
+++ b/src/main/java/com/suse/saltstack/netapi/utils/ClientUtils.java
@@ -56,17 +56,26 @@ public class ClientUtils {
     }
 
     /**
-     * Helper for constructing json object from kwargs and args.
+     * Helper for constructing json object with kwargs and args.
      *
      * @return JsonObject filled with kwargs and args.
      */
-    public static JsonObject makeJsonData(Map<String, String> kwargs, List<String> args) {
+    public static JsonObject makeJsonData(Map<String, String> props,
+            Map<String, String> kwargs, List<String> args) {
         final JsonObject json = new JsonObject();
 
-        if (kwargs != null) {
-            for (Map.Entry<String, String> kwEntry : kwargs.entrySet()) {
-                json.addProperty(kwEntry.getKey(), kwEntry.getValue());
+        if (props != null) {
+            for (Map.Entry<String, String> prop : props.entrySet()) {
+                json.addProperty(prop.getKey(), prop.getValue());
             }
+        }
+
+        if (kwargs != null) {
+            JsonObject kwarg = new JsonObject();
+            for (Map.Entry<String, String> kwEntry : kwargs.entrySet()) {
+                kwarg.addProperty(kwEntry.getKey(), kwEntry.getValue());
+            }
+            json.add("kwarg", kwarg);
         }
 
         if (args != null) {

--- a/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
@@ -71,19 +71,30 @@ public class ClientUtilsTest {
 
     @Test
     public void makeJsonDataEmpty() {
-        JsonObject jsonObject = ClientUtils.makeJsonData(null, null);
+        JsonObject jsonObject = ClientUtils.makeJsonData(null, null, null);
         assertEquals(new JsonObject(), jsonObject);
     }
 
     @Test
     public void makeJsonDataKwargsArgs() {
         JsonObject expected = new JsonObject();
-        expected.addProperty("first", "1");
-        expected.addProperty("snd", "42");
-        JsonArray jsonArray = new JsonArray();
-        jsonArray.add(new JsonPrimitive("foo"));
-        jsonArray.add(new JsonPrimitive("bar"));
-        expected.add("arg", jsonArray);
+        expected.addProperty("tgt", "*");
+        expected.addProperty("fun", "test.ping");
+        JsonObject kwarg = new JsonObject();
+        kwarg.addProperty("first", "1");
+        kwarg.addProperty("snd", "42");
+        expected.add("kwarg", kwarg);
+        JsonArray arg = new JsonArray();
+        arg.add(new JsonPrimitive("foo"));
+        arg.add(new JsonPrimitive("bar"));
+        expected.add("arg", arg);
+
+        Map<String, String> props = new LinkedHashMap<String, String>() {
+            {
+                put("tgt", "*");
+                put("fun", "test.ping");
+            }
+        };
 
         Map<String, String> kwargs = new LinkedHashMap<String, String>() {
             {
@@ -96,7 +107,7 @@ public class ClientUtilsTest {
         args.add("foo");
         args.add("bar");
 
-        JsonObject jsonObject = ClientUtils.makeJsonData(kwargs, args);
+        JsonObject jsonObject = ClientUtils.makeJsonData(props, kwargs, args);
 
         assertEquals(expected, jsonObject);
     }

--- a/src/test/resources/minions_request.json
+++ b/src/test/resources/minions_request.json
@@ -1,9 +1,5 @@
 [
   {
-    "username": "user",
-    "password": "pass",
-    "eauth": "pam",
-    "client": "local",
     "tgt": "*",
     "fun": "pkg.install",
     "arg": ["i3"],
@@ -13,3 +9,4 @@
     }
   }
 ]
+


### PR DESCRIPTION
This fixes #49 and adjusts the test to make sure everything works as expected.

One thing to note here is that we pass the arguments all arguments (positional and named) as `json` strings. At first i thought that would be a problem but after some tests is looks like the server is fine with it and parses the strings to the type of the argument and uses them as expected.
