### PR TITLE
Checkstyle enhancements

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -7,6 +7,11 @@
         <property name="lineSeparator" value="lf"/>
     </module>
     <module name="TreeWalker">
+        <module name="Regexp">
+            <property name="format" value="[ \t]+$"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="message" value="Trailing whitespace"/>
+        </module>
         <module name="LineLength">
             <property name="max" value="92"/>
             <property name="ignorePattern" value="import"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3,7 +3,9 @@
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
     <module name="TreeWalker">
         <module name="LineLength">
             <property name="max" value="92"/>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <linkXRef>false</linkXRef>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
+++ b/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
@@ -17,7 +17,7 @@ public class ClientConfig {
      * A timeout of zero is interpreted as an infinite timeout.
      * A negative value is interpreted as undefined (system default).
      * Default value is 10000ms (10s)
-     * 
+     *
      * @see HttpClientConnection.request(String)
      * @see JDKConnection.request(String, String)
      */
@@ -28,7 +28,7 @@ public class ClientConfig {
      * A timeout of zero is interpreted as an infinite timeout.
      * A negative value is interpreted as undefined (system default).
      * Default value is 10000ms (10s)
-     * 
+     *
      * @see HttpClientConnection.request(String)
      * @see JDKConnection.request(String, String)
      */

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -27,9 +27,23 @@ import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * SaltStack API unit tests.
@@ -74,9 +88,9 @@ public class SaltStackClientTest {
                 .withHeader("Content-Type", equalTo("application/json"))
                 .withRequestBody(equalToJson(JSON_LOGIN_REQUEST))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_OK)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(JSON_LOGIN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_LOGIN_RESPONSE)));
 
         Token token = client.login("user", "pass");
         assertEquals("Token mismatch",
@@ -92,7 +106,7 @@ public class SaltStackClientTest {
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json"))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_UNAUTHORIZED)));
+                .withStatus(HttpURLConnection.HTTP_UNAUTHORIZED)));
         client.login("user", "pass");
     }
 
@@ -103,9 +117,9 @@ public class SaltStackClientTest {
                 .withHeader("Content-Type", equalTo("application/json"))
                 .withRequestBody(equalToJson(JSON_LOGIN_REQUEST))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_OK)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(JSON_LOGIN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_LOGIN_RESPONSE)));
 
         Future<Token> futureToken = client.loginAsync("user", "pass");
         Token token = futureToken.get();
@@ -123,7 +137,7 @@ public class SaltStackClientTest {
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json"))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_UNAUTHORIZED)));
+                .withStatus(HttpURLConnection.HTTP_UNAUTHORIZED)));
 
         Future<Token> futureToken = client.loginAsync("user", "pass");
         Token token = futureToken.get();
@@ -134,9 +148,9 @@ public class SaltStackClientTest {
     public void testRunRequest() throws Exception {
         stubFor(post(urlEqualTo("/run"))
                 .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_OK)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(JSON_RUN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_RUN_RESPONSE)));
 
         List<String> args = new ArrayList<>();
         args.add("i3");
@@ -161,9 +175,9 @@ public class SaltStackClientTest {
     public void testRunRequestAsync() throws Exception {
         stubFor(post(urlEqualTo("/run"))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_OK)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(JSON_RUN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_RUN_RESPONSE)));
 
         List<String> args = new ArrayList<>();
         args.add("i3");
@@ -210,10 +224,11 @@ public class SaltStackClientTest {
         exception.expect(SaltStackException.class);
         exception.expectMessage(containsString("Read timed out"));
 
-        // create a local SaltStackClient with a fast timeout configuration 
+        // create a local SaltStackClient with a fast timeout configuration
         // to do not lock tests more than 2s
         URI uri = URI.create("http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
-        SaltStackClient clientWithFastTimeout = new SaltStackClient(uri, new JDKConnectionFactory());
+        SaltStackClient clientWithFastTimeout = new SaltStackClient(uri,
+                new JDKConnectionFactory());
         clientWithFastTimeout.getConfig().put(SOCKET_TIMEOUT, 1000);
 
         stubFor(post(urlEqualTo("/login"))
@@ -229,9 +244,9 @@ public class SaltStackClientTest {
     public void testRunResult() throws Exception {
         stubFor(post(urlEqualTo("/run"))
                 .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_OK)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(JSON_RUN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_RUN_RESPONSE)));
 
         Map<String, Object> retvals = client.run("user", "pass", "pam", "local", "*",
                 "test.ping", null, null);
@@ -245,9 +260,9 @@ public class SaltStackClientTest {
     public void testRunResultAsync() throws Exception {
         stubFor(post(urlEqualTo("/run"))
                 .willReturn(aResponse()
-                        .withStatus(HttpURLConnection.HTTP_OK)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(JSON_RUN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_RUN_RESPONSE)));
 
         Future<Map<String, Object>> future = client.runAsync("user", "pass",
                 "pam", "local", "*", "test.ping", null, null);
@@ -262,8 +277,8 @@ public class SaltStackClientTest {
     public void testStartCommand() throws Exception {
         stubFor(post(urlEqualTo("/minions")).willReturn(
                 aResponse().withStatus(HttpURLConnection.HTTP_OK)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(JSON_START_COMMAND_RESPONSE)));
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_START_COMMAND_RESPONSE)));
 
         List<String> args = new ArrayList<>();
         args.add("i3");
@@ -291,9 +306,9 @@ public class SaltStackClientTest {
     public void testQueryJobResult() throws Exception {
         stubFor(get(urlEqualTo("/jobs/some-job-id"))
                 .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_OK)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(JSON_RUN_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_RUN_RESPONSE)));
 
         Map<String, Object> retvals = client.getJobResult("some-job-id");
 
@@ -305,9 +320,9 @@ public class SaltStackClientTest {
     @Test
     public void testStartCommandAsync() throws Exception {
         stubFor(post(urlEqualTo("/minions")).willReturn(
-                 aResponse().withStatus(HttpURLConnection.HTTP_OK)
-                         .withHeader("Content-Type", "application/json")
-                         .withBody(JSON_START_COMMAND_RESPONSE)));
+                aResponse().withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_START_COMMAND_RESPONSE)));
 
         List<String> args = new ArrayList<>();
         args.add("i3");
@@ -336,9 +351,9 @@ public class SaltStackClientTest {
     public void testStats() throws Exception {
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_OK)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(JSON_STATS_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_STATS_RESPONSE)));
 
         Stats stats = client.stats();
 
@@ -352,9 +367,9 @@ public class SaltStackClientTest {
     public void testStatsAsync() throws Exception {
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_OK)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(JSON_STATS_RESPONSE)));
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_STATS_RESPONSE)));
 
         Stats stats = client.statsAsync().get();
 

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -204,7 +204,7 @@ public class SaltStackClientTest {
         exception.expect(SaltStackException.class);
         exception.expectMessage(containsString("Read timed out"));
 
-        // create a local SaltStackClient with a fast timeout configuration 
+        // create a local SaltStackClient with a fast timeout configuration
         // to do not lock tests more than 2s
         URI uri = URI.create("http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
         SaltStackClient clientWithFastTimeout = new SaltStackClient(uri);

--- a/src/test/java/com/suse/saltstack/netapi/config/ClientConfigTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/config/ClientConfigTest.java
@@ -1,10 +1,14 @@
 package com.suse.saltstack.netapi.config;
 
-import static com.suse.saltstack.netapi.config.ClientConfig.*;
-
-import static org.junit.Assert.assertEquals;
+import com.suse.saltstack.netapi.config.ClientConfig.Key;
 import org.junit.Test;
 
+import static com.suse.saltstack.netapi.config.ClientConfig.PROXY_PORT;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Configuration unit tests.
+ */
 public class ClientConfigTest {
 
     @Test

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -2,7 +2,11 @@ package com.suse.saltstack.netapi.parser;
 
 import com.google.gson.JsonParseException;
 import com.suse.saltstack.netapi.datatypes.Job;
-import com.suse.saltstack.netapi.datatypes.cherrypy.*;
+import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
+import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
+import com.suse.saltstack.netapi.datatypes.cherrypy.Request;
+import com.suse.saltstack.netapi.datatypes.cherrypy.ServerThread;
+import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.datatypes.Token;
 import java.util.Date;
@@ -14,6 +18,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * Json parser unit tests.
+ */
 public class JsonParserTest {
 
     @Test
@@ -114,7 +121,7 @@ public class JsonParserTest {
         assertEquals(10, server.getWriteThroughput(), 0);
 
         for (int i = 0; i < server.getThreads(); i++) {
-            ServerThread thread = server.getWorkerThreads().get("CP Server Thread-"+i);
+            ServerThread thread = server.getWorkerThreads().get("CP Server Thread-" + i);
             assertEquals(0, thread.getBytesRead());
             assertEquals(2, thread.getBytesWritten());
             assertEquals(3.4, thread.getReadThroughput(), 0);

--- a/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
@@ -23,7 +23,9 @@ public class ClientUtilsTest {
 
     @Test
     public void testCloseQuietly() throws IOException {
-        // Mocked InputStream that throws IOException when closed more than once.
+        /**
+         * Mocked InputStream that throws IOException when closed more than once.
+         */
         class MockedInputStream extends InputStream {
             private boolean closed = false;
 


### PR DESCRIPTION
This PR fixes #52. Additionally the 2 other commits enhance the checkstyle rules by making the `NewlineAtEndOfFile` rule system independent and adding a rule that complains about trailing whitespace.