### PR TITLE
Implement keys endpoint with no parameters.

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -4,6 +4,7 @@ import com.suse.saltstack.netapi.Constants;
 import com.suse.saltstack.netapi.client.impl.HttpClientConnectionFactory;
 import com.suse.saltstack.netapi.config.ClientConfig;
 import com.suse.saltstack.netapi.config.ProxySettings;
+import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
@@ -405,6 +406,36 @@ public class SaltStackClient {
             @Override
             public Stats call() throws SaltStackException {
                 return stats();
+            }
+        };
+        return executor.submit(callable);
+    }
+
+    /**
+     * Query general key information.
+     *
+     * GET /keys
+     *
+     * @return The {@link Keys} object.
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Keys keys() throws SaltStackException {
+        return connectionFactory.create("/keys", JsonParser.KEYS, config).getResult()
+                .getResult();
+    }
+
+    /**
+     * Asynchronously query general key information.
+     *
+     * GET /keys
+     *
+     * @return Future containing the {@link Keys} object.
+     */
+    public Future<Keys> keysAsync() {
+        Callable<Keys> callable = new Callable<Keys>() {
+            @Override
+            public Keys call() throws SaltStackException {
+                return keys();
             }
         };
         return executor.submit(callable);

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -414,6 +414,8 @@ public class SaltStackClient {
     /**
      * Query general key information.
      *
+     * Required persmissions: @wheel
+     *
      * GET /keys
      *
      * @return The {@link Keys} object.
@@ -426,6 +428,8 @@ public class SaltStackClient {
 
     /**
      * Asynchronously query general key information.
+     *
+     * Required persmissions: @wheel
      *
      * GET /keys
      *

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Keys.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Keys.java
@@ -1,0 +1,37 @@
+package com.suse.saltstack.netapi.datatypes;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Saltstack Keys information.
+ */
+public class Keys {
+
+    private List<String> local;
+
+    private List<String> minions;
+
+    @SerializedName("minions_pre")
+    private List<String> unacceptedMinions;
+
+    @SerializedName("minions_rejected")
+    private List<String> rejectedMinions;
+
+    public List<String> getLocal() {
+        return local;
+    }
+
+    public List<String> getMinions() {
+        return minions;
+    }
+
+    public List<String> getUnacceptedMinions() {
+        return unacceptedMinions;
+    }
+
+    public List<String> getRejectedMinions() {
+        return rejectedMinions;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
 import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
@@ -41,6 +42,8 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Stats> STATS =
             new JsonParser<>(new TypeToken<Stats>(){});
+    public static final JsonParser<Result<Keys>> KEYS =
+            new JsonParser<>(new TypeToken<Result<Keys>>(){});
 
     private final TypeToken<T> type;
     private final Gson gson;

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -5,6 +5,7 @@ import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.client.impl.JDKConnectionFactory;
 import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.Token;
+import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.utils.ClientUtils;
 
 import static com.suse.saltstack.netapi.config.ClientConfig.SOCKET_TIMEOUT;
@@ -66,6 +67,8 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/run_response.json"));
     static final String JSON_STATS_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/stats_response.json"));
+    static final String JSON_KEYS_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream("/keys_response.json"));
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -375,6 +378,38 @@ public class SaltStackClientTest {
 
         assertNotNull(stats);
         verify(1, getRequestedFor(urlEqualTo("/stats"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testKeys() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_KEYS_RESPONSE)));
+
+        Keys keys = client.keys();
+
+        assertNotNull(keys);
+        verify(1, getRequestedFor(urlEqualTo("/keys"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testKeysAsync() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_KEYS_RESPONSE)));
+
+        Keys keys = client.keysAsync().get();
+
+        assertNotNull(keys);
+        verify(1, getRequestedFor(urlEqualTo("/keys"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));
     }

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -2,6 +2,7 @@ package com.suse.saltstack.netapi.parser;
 
 import com.google.gson.JsonParseException;
 import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
 import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Request;
@@ -10,6 +11,7 @@ import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.datatypes.Token;
 import java.util.Date;
+import java.util.Arrays;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -129,5 +131,17 @@ public class JsonParserTest {
             assertEquals(6, thread.getWorkTime(), 0);
             assertEquals(7.8, thread.getWriteThroughput(), 0);
         }
+    }
+
+    @Test
+    public void testKeysParser() throws Exception {
+        InputStream is = getClass().getResourceAsStream("/keys_response.json");
+        Result<Keys> result = JsonParser.KEYS.parse(is);
+        Keys keys = result.getResult();
+        assertNotNull("failed to parse", result);
+        assertEquals(Arrays.asList("master.pem", "master.pub"), keys.getLocal());
+        assertEquals(Arrays.asList("m1"), keys.getMinions());
+        assertEquals(Arrays.asList("m2"), keys.getUnacceptedMinions());
+        assertEquals(Arrays.asList("m3"), keys.getRejectedMinions());
     }
 }

--- a/src/test/resources/keys_response.json
+++ b/src/test/resources/keys_response.json
@@ -1,0 +1,11 @@
+{
+  "return": {
+    "minions_pre": ["m2"],
+    "minions_rejected": ["m3"],
+    "local": [
+      "master.pem",
+      "master.pub"
+    ],
+    "minions": ["m1"]
+  }
+}


### PR DESCRIPTION
This PR implements the basic `/keys` endpoint with no parameters. There are 3 more endpoints related to key management which will be part of separate PRs once i figure out the details.