### PR TITLE
Fix maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,9 @@
   <name>saltstack-netapi-client-java</name>
   <url>https://github.com/SUSE/saltstack-netapi-client-java</url>
   <description>Java client to access the SaltStack net-api</description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
This makes the maven warnings go away and the encoding no longer dependent on the platform.