### PR TITLE
Add job start time to Job class

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
@@ -1,14 +1,21 @@
 package com.suse.saltstack.netapi.datatypes;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.suse.saltstack.netapi.parser.JsonParser;
 
-// TODO - handle dates too (they are represented in really
-// exotic format: (2015, Mar 04 19:28:29.724698))
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * Representation of a previously run job.
  */
 public class Job {
+
+    // StartTime example from API: "2015, Mar 04 19:28:29.724698"
+    public static final SimpleDateFormat START_TIME_FORMAT =
+            new SimpleDateFormat("yyyy, MMM dd HH:mm:ss.SSS", Locale.US);
 
     @SerializedName("Function")
     private String function;
@@ -24,6 +31,13 @@ public class Job {
 
     @SerializedName("Arguments")
     private Arguments arguments;
+
+    /**
+     * Please note that start time will be in salt-master time zone
+     */
+    @SerializedName("StartTime")
+    @JsonAdapter(JsonParser.JobStartTimeJsonAdapter.class)
+    private Date startTime;
 
     public String getFunction() {
         return function;
@@ -43,5 +57,9 @@ public class Job {
 
     public Arguments getArguments() {
         return arguments;
+    }
+
+    public Date getStartTime() {
+        return startTime;
     }
 }

--- a/src/main/java/com/suse/saltstack/netapi/exception/ParsingException.java
+++ b/src/main/java/com/suse/saltstack/netapi/exception/ParsingException.java
@@ -1,9 +1,11 @@
 package com.suse.saltstack.netapi.exception;
 
+import java.io.IOException;
+
 /**
  * Exception to be thrown in case of problems parsing service responses.
  */
-public class ParsingException extends SaltStackException {
+public class ParsingException extends IOException {
 
     /**
      * Constructor expecting a custom cause.

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -20,6 +20,7 @@ import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
 import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
+import com.suse.saltstack.netapi.exception.ParsingException;
 import com.suse.saltstack.netapi.results.Result;
 
 import java.io.BufferedReader;
@@ -220,7 +221,7 @@ public class JsonParser<T> {
     }
 
     /**
-     * Json adapter to handle the StartTime date format given by netapi
+     * Json adapter to handle the Job.StartTime date format given by netapi
      */
     public class JobStartTimeJsonAdapter extends TypeAdapter<Date> {
         @Override
@@ -245,8 +246,7 @@ public class JsonParser<T> {
                 dateStr = dateStr.substring(0, dateStr.length() - 3);
                 return Job.START_TIME_FORMAT.parse(dateStr);
             } catch (ParseException e) {
-                e.printStackTrace();
-                return null;
+                throw new ParsingException(e);
             }
         }
     }

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -7,11 +7,15 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
 import com.suse.saltstack.netapi.datatypes.Arguments;
 import com.suse.saltstack.netapi.datatypes.Job;
-import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Keys;
+import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Applications;
 import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
@@ -19,10 +23,12 @@ import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.results.Result;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -209,6 +215,38 @@ public class JsonParser<T> {
             if (jsonElement.isJsonObject()
                     && jsonElement.getAsJsonObject().has(KWARG_KEY)) {
                 jsonElement.getAsJsonObject().remove(KWARG_KEY);
+            }
+        }
+    }
+
+    /**
+     * Json adapter to handle the StartTime date format given by netapi
+     */
+    public class JobStartTimeJsonAdapter extends TypeAdapter<Date> {
+        @Override
+        public synchronized void write(JsonWriter out, Date value) throws IOException {
+            if (value == null) {
+                out.nullValue();
+                return;
+            }
+            String dateFormatAsString = Job.START_TIME_FORMAT.format(value);
+            out.value(dateFormatAsString);
+        }
+
+        @Override
+        public synchronized Date read(JsonReader in) throws IOException {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            try {
+                String dateStr = in.nextString();
+                // Remove microseconds because java Date does not support it
+                dateStr = dateStr.substring(0, dateStr.length() - 3);
+                return Job.START_TIME_FORMAT.parse(dateStr);
+            } catch (ParseException e) {
+                e.printStackTrace();
+                return null;
             }
         }
     }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -1,26 +1,15 @@
 package com.suse.saltstack.netapi.client;
 
-import com.suse.saltstack.netapi.datatypes.Job;
-import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
-import com.suse.saltstack.netapi.exception.SaltStackException;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonSyntaxException;
 import com.suse.saltstack.netapi.client.impl.JDKConnectionFactory;
+import com.suse.saltstack.netapi.datatypes.Job;
+import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Token;
-import com.suse.saltstack.netapi.datatypes.Keys;
+import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
+import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.utils.ClientUtils;
-
-import static com.suse.saltstack.netapi.config.ClientConfig.SOCKET_TIMEOUT;
-import static com.suse.saltstack.netapi.AuthModule.PAM;
-import static com.suse.saltstack.netapi.AuthModule.AUTO;
-
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +17,11 @@ import org.junit.rules.ExpectedException;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -43,6 +37,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.suse.saltstack.netapi.AuthModule.AUTO;
+import static com.suse.saltstack.netapi.AuthModule.PAM;
+import static com.suse.saltstack.netapi.config.ClientConfig.SOCKET_TIMEOUT;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -62,7 +59,7 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/minions_response.json"));
     static final String JSON_LOGIN_REQUEST = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/login_request.json"));
-    static final String JSON_LOGIN_RESPONSE =  ClientUtils.streamToString(
+    static final String JSON_LOGIN_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/login_response.json"));
     static final String JSON_RUN_REQUEST = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/run_request.json"));
@@ -74,6 +71,12 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/keys_response.json"));
     static final String JSON_JOBS_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/jobs_response.json"));
+    static final String JSON_JOBS_INVALID_START_TIME_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream(
+            "/jobs_response_invalid_start_time.json"));
+    static final String JSON_JOBS_NULL_START_TIME_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream(
+            "/jobs_response_null_start_time.json"));
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -431,8 +434,53 @@ public class SaltStackClientTest {
         Map<String, Job> jobs = client.getJobs();
 
         assertNotNull(jobs);
+        Job job1 = jobs.get("20150304192951636258");
+        Job job2 = jobs.get("20150304200110485012");
         assertEquals(Arrays.asList("enable-autodestruction"),
-                jobs.get("20150304200110485012").getArguments().getArgs());
+                job2.getArguments().getArgs());
+        assertEquals(0, job1.getArguments().getArgs().size());
+        assertEquals(1425493791636L, job1.getStartTime().getTime());
+        assertEquals(1425495670485L, job2.getStartTime().getTime());
+        verify(1, getRequestedFor(urlEqualTo("/jobs"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testJobsWithInvalidStartTime() throws Exception {
+        stubFor(get(urlMatching("/jobs"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_INVALID_START_TIME_RESPONSE)));
+
+        boolean exceptionThrown = false;
+        try {
+            client.getJobs();
+        } catch (JsonSyntaxException e) {
+            exceptionThrown = true;
+        }
+        assertTrue("Expected JsonSyntaxException to be thrown", exceptionThrown);
+        verify(1, getRequestedFor(urlEqualTo("/jobs"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testJobsWithNullStartTime() throws Exception {
+        stubFor(get(urlMatching("/jobs"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_NULL_START_TIME_RESPONSE)));
+
+        Map<String, Job> jobs = client.getJobs();
+
+        assertNotNull(jobs);
+        Job job1 = jobs.get("20150304192951636258");
+        Job job2 = jobs.get("20150304200110485012");
+        assertNull(job1.getStartTime());
+        assertNull(job2.getStartTime());
         verify(1, getRequestedFor(urlEqualTo("/jobs"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -17,6 +17,7 @@ import org.junit.rules.ExpectedException;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -77,6 +78,9 @@ public class SaltStackClientTest {
     static final String JSON_JOBS_NULL_START_TIME_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream(
             "/jobs_response_null_start_time.json"));
+
+    private static final SimpleDateFormat DATE_FORMAT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -439,8 +443,8 @@ public class SaltStackClientTest {
         assertEquals(Arrays.asList("enable-autodestruction"),
                 job2.getArguments().getArgs());
         assertEquals(0, job1.getArguments().getArgs().size());
-        assertEquals(1425493791636L, job1.getStartTime().getTime());
-        assertEquals(1425495670485L, job2.getStartTime().getTime());
+        assertEquals("2015-03-04 19:29:51", DATE_FORMAT.format(job1.getStartTime()));
+        assertEquals("2015-03-04 20:01:10", DATE_FORMAT.format(job2.getStartTime()));
         verify(1, getRequestedFor(urlEqualTo("/jobs"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));

--- a/src/test/resources/jobs_response_invalid_start_time.json
+++ b/src/test/resources/jobs_response_invalid_start_time.json
@@ -1,0 +1,24 @@
+{
+  "return": [
+    {
+      "20150304192951636258": {
+        "Arguments": [],
+        "Function": "test.ping",
+        "StartTime": "2015, Mar 04 19:29:51.636258",
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      },
+      "20150304200110485012": {
+        "Arguments": [
+          "enable-autodestruction"
+        ],
+        "Function": "test.echo",
+        "StartTime": "2015-04-25T11:12:13Z",
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      }
+    }
+  ]
+}

--- a/src/test/resources/jobs_response_null_start_time.json
+++ b/src/test/resources/jobs_response_null_start_time.json
@@ -1,0 +1,23 @@
+{
+  "return": [
+    {
+      "20150304192951636258": {
+        "Arguments": [],
+        "Function": "test.ping",
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      },
+      "20150304200110485012": {
+        "Arguments": [
+          "enable-autodestruction"
+        ],
+        "Function": "test.echo",
+        "StartTime": null,
+        "Target": "*",
+        "Target-type": "glob",
+        "User": "chuck"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds start time to Job class.

Salt JobIds are made from the date and time when the job was created (example from today - May 3, 2015: 20150503195439947382). Unfortunately, Salt Master does not use UTC when constructing these Id's, meaning the master's current time zone is used which is unknown to the minion and so it gets lost when translating the JobId into a StartTime.

One could argue that it would be easier to just parse the JobId instead of the strange date format that cherrypy returns, but I don't think we should rely on JobId's having this format forever.

It would be much better if cherrypy returned a timestamp instead. That would mean that the minion can translate the date and time into it's own time zone. Parsing would also be easier and more reliable.