### PR TITLE
Refactor HttpClientConnection into shorter methods

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/exception/SaltUserUnauthorizedException.java
+++ b/src/main/java/com/suse/saltstack/netapi/exception/SaltUserUnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.suse.saltstack.netapi.exception;
+
+/**
+ * Exception for when a user is logged in but not allowed
+ * access to the requested resource.
+ */
+public class SaltUserUnauthorizedException extends SaltStackException {
+
+    public SaltUserUnauthorizedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
request() method in HttpClientConnection was way too long (69 lines), so I decided to refactor it into more smaller methods to make it clearer and abstract away implementation details down in the individual methods.