### PR TITLE
Add automagic javadoc publishing for tags and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,22 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 install: /bin/true
-script: mvn checkstyle:check test package
+script: mvn checkstyle:check javadoc:javadoc test package
 before_deploy:
   - export RELEASE_JAR_FILE=$(ls target/saltstack-netapi-client-*.jar)
   - echo "Deploying $RELEASE_JAR_FILE to GitHub releases"
 deploy:
   provider: releases
   api_key:
-    secure: Gzz8W8cnLBgui3dh9yCl+z72qLd22T2N35QBqEIZIB38WGDMfKliQ2xrxYz4YkH3SeH+rcu8xzL9gEKd7YIA7pp6R7Q5wy+i2F2whC8kbC8qaOQLvpNfdzadwLS11ExtqSOMebxphJxzMYXjW/LWQ2AH4Df7wUwTy+cVX9oRWfs=
+    secure: braT4pMYLy0ocRgNt4MrI0kWUPnQF455RNLXBAf3+ArSiCMpaoQkwoDnauI155+Kaq2sXDuFg/vCdNQ0h4Rd33qEW5vg810wQQKj9lleDJmfv2W6/DxpTDnvySR4ChAWv9BZBMFIPhdv/dfZWgZBFHluvXw2Bi4UMF0GXsNPjYs=
   file_glob: true
   file: "${RELEASE_JAR_FILE}"
   skip_cleanup: true
   on:
     repo: SUSE/saltstack-netapi-client-java
     tags: true
+after_success:
+  - scripts/publish_javadoc.sh
+env:
+  global:
+    - secure: XvflMMZoyQSbsCdOD98rFxsEvd+c9aNUulPf0IIKpp6OFcl0lEoq6c4cEd0C/qBtlZgBNTYmnWfOpWcrNZABa2PXAbi0p9lw/5/L9UgnlEfWG0NbVbJ/arb2DidgnidvVT5GhNNn31/38zwVcJVyo3yjRmf72ZwPbZKWGygKkjc=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # saltstack-netapi-client-java [![Build Status](https://travis-ci.org/SUSE/saltstack-netapi-client-java.svg?branch=master)](https://travis-ci.org/SUSE/saltstack-netapi-client-java)
 
-Java bindings for the [SaltStack API] (http://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#module-salt.netapi.rest_cherrypy.app), please have a look at the [Javadoc] (http://suse.github.io/saltstack-netapi-client-java/docs/v0.1.0).
+Java bindings for the [SaltStack API] (http://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#module-salt.netapi.rest_cherrypy.app), please have a look at the Javadoc for [v0.1.0] (http://suse.github.io/saltstack-netapi-client-java/docs/v0.1.0) or [master](http://suse.github.io/saltstack-netapi-client-java/docs/master).
 
 ## Contributing
 

--- a/scripts/publish_javadoc.sh
+++ b/scripts/publish_javadoc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8"  &&  "$TRAVIS_PULL_REQUEST" == "false"  &&  ("$TRAVIS_BRANCH" == "master" || "$TRAVIS_TAG") ]]; then
+
+  cp -R target/site/apidocs $HOME/javadoc-latest
+
+  cd $HOME
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "travis-ci"
+  git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} gh-pages
+
+  if [[ "$TRAVIS_TAG" ]]; then
+    DOC_DIR=$TRAVIS_TAG
+  elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
+    DOC_DIR=$TRAVIS_BRANCH
+  fi
+
+  cd gh-pages
+  git rm -rf ./docs/${DOC_DIR}
+  cp -Rf $HOME/javadoc-latest ./docs/${DOC_DIR}
+  git add -f .
+  git commit -m "Travis auto publish javadoc for $DOC_DIR"
+  git push -fq origin gh-pages
+
+fi


### PR DESCRIPTION
This is a first draft for the automatic publishing of `javadocs` to `gh-pages`.
This will (or at least should) publish the `master` branch at `gh-pages/docs/master` and
`tags` at `gh-pages/docs/<TAG>`.
I tested it on my fork and it seems to work fine but i would really appreciate if you could review this carefully since i'm pretty bad at writing `bash` scripts.