### PR TITLE
Fix logout to actually perform a POST request

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -166,13 +166,17 @@ public class SaltStackClient {
      * <p>
      * {@code POST /logout}
      *
-     * @return String result as returned from the API
+     * @return true if the logout was successful, otherwise false
      * @throws SaltStackException if anything goes wrong
      */
-    public Result<String> logout() throws SaltStackException {
-        Result<String> result = connectionFactory
+    public boolean logout() throws SaltStackException {
+        Result<String> stringResult = connectionFactory
                 .create("/logout", JsonParser.STRING, config).getResult("");
-        config.remove(ClientConfig.TOKEN);
+        String logoutMessage = "Your token has been cleared";
+        boolean result = logoutMessage.equals((stringResult.getResult()));
+        if (result) {
+            config.remove(ClientConfig.TOKEN);
+        }
         return result;
     }
 
@@ -181,12 +185,12 @@ public class SaltStackClient {
      * <p>
      * {@code POST /logout}
      *
-     * @return Future containing String result as returned from the API
+     * @return Future containing a boolean result, true if logout was successful
      */
-    public Future<Result<String>> logoutAsync() {
-        Callable<Result<String>> callable = new Callable<Result<String>>() {
+    public Future<Boolean> logoutAsync() {
+        Callable<Boolean> callable = new Callable<Boolean>() {
             @Override
-            public Result<String> call() throws SaltStackException {
+            public Boolean call() throws SaltStackException {
                 return logout();
             }
         };

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -171,7 +171,7 @@ public class SaltStackClient {
      */
     public Result<String> logout() throws SaltStackException {
         Result<String> result = connectionFactory
-                .create("/logout", JsonParser.STRING, config).getResult(null);
+                .create("/logout", JsonParser.STRING, config).getResult("");
         config.remove(ClientConfig.TOKEN);
         return result;
     }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -90,6 +90,8 @@ public class SaltStackClientTest {
             "/jobs_response_null_start_time.json"));
     static final String JSON_HOOK_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/hook_response.json"));
+    static final String JSON_LOGOUT_RESPONSE = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream("/logout_response.json"));
 
     private static final SimpleDateFormat DATE_FORMAT =
             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -755,4 +757,37 @@ public class SaltStackClientTest {
                 .withRequestBody(equalTo(data)));
     }
 
+    @Test
+    public void testLogout() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_LOGOUT_RESPONSE)));
+
+        boolean success = client.logout();
+
+        assertTrue(success);
+        verify(1, postRequestedFor(urlEqualTo("/logout"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testLogoutAsync() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_LOGOUT_RESPONSE)));
+
+        boolean success = client.logoutAsync().get();
+
+        assertTrue(success);
+        verify(1, postRequestedFor(urlEqualTo("/logout"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
 }

--- a/src/test/resources/logout_response.json
+++ b/src/test/resources/logout_response.json
@@ -1,12 +1,3 @@
 {
-  "clients": [
-    "local",
-    "local_async",
-    "local_batch",
-    "runner",
-    "runner_async",
-    "wheel",
-    "wheel_async"
-  ],
-  "return": "Welcome"
+  "return": "Your token has been cleared"
 }


### PR DESCRIPTION
This patch should fix the `logout()` and `logoutAsync()` methods to actually perform a POST request. Recently we accidentally sent a GET request here since the `data` passed in to `create()` was `null`. The proposed patch is just a quick fix, we might want to reconsider the behaviour of the `create()` method that does actually create a GET request whenever the given data is `null`.

Further this pull request adds missing unit tests for `logout()` and `logoutAsync()` and the example response (`logout_response.json`) has been fixed.

This fixes issue #64.