### PR TITLE
Replace SaltStackDateDeserializer with DateAdapter

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -72,7 +72,7 @@ public class JsonParser<T> {
     public JsonParser(TypeToken<T> type) {
         this.type = type;
         this.gson = new GsonBuilder()
-                .registerTypeAdapter(Date.class, new SaltStackDateDeserializer())
+                .registerTypeAdapter(Date.class, new DateAdapter().nullSafe())
                 .registerTypeAdapter(Stats.class, new StatsDeserializer())
                 .registerTypeAdapter(Arguments.class, new ArgumentsDeserializer())
                 .create();
@@ -92,18 +92,22 @@ public class JsonParser<T> {
     }
 
     /**
-     * Deserializer for date representation received from the API
+     * TypeAdapter for date representation received from the API
      * (which represents it as a (floating) number of seconds since the Epoch).
      */
-    private class SaltStackDateDeserializer implements JsonDeserializer<Date> {
+    private class DateAdapter extends TypeAdapter<Date> {
+
         @Override
-        public Date deserialize(JsonElement jsonElement, Type type,
-                JsonDeserializationContext jsonDeserializationContext)
-                throws JsonParseException {
+        public void write(JsonWriter jsonWriter, Date date) throws IOException {
+            throw new UnsupportedOperationException("Writing JSON not supported.");
+        }
+
+        @Override
+        public Date read(JsonReader jsonReader) throws IOException {
             try {
-                double dateMiliSecs = jsonElement.getAsDouble() * 1000;
-                return new Date((long) dateMiliSecs);
-            } catch (NumberFormatException e) {
+                double dateMilliseconds = jsonReader.nextDouble() * 1000;
+                return new Date((long) dateMilliseconds);
+            } catch (NumberFormatException | IllegalStateException e) {
                 throw new JsonParseException(e);
             }
         }

--- a/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/parser/JsonParserTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Json parser unit tests.
@@ -62,6 +63,15 @@ public class JsonParserTest {
     public void testSaltStackTokenParserWrongDate() throws Exception {
         InputStream is = getClass().getResourceAsStream("/login_response_wrong_date.json");
         JsonParser.TOKEN.parse(is);
+    }
+
+    @Test
+    public void testSaltStackTokenParserDateMissing() throws Exception {
+        InputStream is = getClass()
+                .getResourceAsStream("/login_response_missing_date.json");
+        Token token = JsonParser.TOKEN.parse(is).getResult().get(0);
+        assertNull(token.getStart());
+        assertNull(token.getExpire());
     }
 
     @Test

--- a/src/test/resources/login_response_missing_date.json
+++ b/src/test/resources/login_response_missing_date.json
@@ -1,0 +1,13 @@
+{
+  "return": [
+    {
+      "perms": [
+        ".*",
+        "@wheel"
+      ],
+      "token": "f248284b655724ca8a86bcab4b8df608ebf5b08b",
+      "user": "user",
+      "eauth": "auto"
+    }
+  ]
+}


### PR DESCRIPTION
TypeAdapters are stream-oriented and more memory effecient than
(tree-based) Deserializers.