### PR TITLE
Support expr_form in run and startCommand

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -10,6 +10,7 @@ import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
+import com.suse.saltstack.netapi.datatypes.target.Target;
 import com.suse.saltstack.netapi.event.EventStream;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
@@ -122,7 +123,7 @@ public class SaltStackClient {
      */
     public Token login(final String username, final String password, final AuthModule eauth)
             throws SaltStackException {
-        Map<String, String> props = new LinkedHashMap<String, String>() {
+        Map<String, Object> props = new LinkedHashMap<String, Object>() {
             {
                 put("username", username);
                 put("password", password);
@@ -257,11 +258,12 @@ public class SaltStackClient {
      * @return object representing the scheduled job
      * @throws SaltStackException if anything goes wrong
      */
-    public ScheduledJob startCommand(final String target, final String function,
+    public <T> ScheduledJob startCommand(final Target<T> target, final String function,
             List<String> args, Map<String, String> kwargs) throws SaltStackException {
-        Map<String, String> props = new LinkedHashMap<String, String>() {
+        Map<String, Object> props = new LinkedHashMap<String, Object>() {
             {
-                put("tgt", target);
+                put("expr_form", target.targetType());
+                put("tgt", target.target());
                 put("fun", function);
             }
         };
@@ -290,7 +292,7 @@ public class SaltStackClient {
      * @param kwargs map containing keyword arguments
      * @return Future containing the scheduled job
      */
-    public Future<ScheduledJob> startCommandAsync(final String target,
+    public <T> Future<ScheduledJob> startCommandAsync(final Target<T> target,
             final String function, final List<String> args,
             final Map<String, String> kwargs) {
         return executor.submit(() -> startCommand(target, function, args, kwargs));
@@ -370,17 +372,18 @@ public class SaltStackClient {
      * @return Map key: minion id, value: command result from that minion
      * @throws SaltStackException if anything goes wrong
      */
-    public Map<String, Object> run(final String username, final String password,
-            final AuthModule eauth, final String client, final String target,
+    public <T> Map<String, Object> run(final String username, final String password,
+            final AuthModule eauth, final String client, final Target<T> target,
             final String function, List<String> args, Map<String, String> kwargs)
             throws SaltStackException {
-        Map<String, String> props = new LinkedHashMap<String, String>() {
+        Map<String, Object> props = new LinkedHashMap<String, Object>() {
             {
                 put("username", username);
                 put("password", password);
                 put("eauth", eauth.getValue());
                 put("client", client);
-                put("tgt", target);
+                put("expr_form", target.targetType());
+                put("tgt", target.target());
                 put("fun", function);
             }
         };
@@ -411,9 +414,9 @@ public class SaltStackClient {
      * @param kwargs map containing keyword arguments
      * @return Future containing Map key: minion id, value: command result from that minion
      */
-    public Future<Map<String, Object>> runAsync(final String username,
+    public <T> Future<Map<String, Object>> runAsync(final String username,
             final String password, final AuthModule eauth, final String client,
-            final String target, final String function, final List<String> args,
+            final Target<T> target, final String function, final List<String> args,
             final Map<String, String> kwargs) {
         return executor.submit(() ->
                 run(username, password, eauth, client, target, function, args, kwargs));

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/target/Glob.java
@@ -1,0 +1,27 @@
+package com.suse.saltstack.netapi.datatypes.target;
+
+/**
+ * Target for specifying minions by glob pattern.
+ */
+public class Glob implements Target<String> {
+
+    private final String glob;
+
+    public Glob() {
+        this("*");
+    }
+
+    public Glob(String glob) {
+        this.glob = glob;
+    }
+
+    @Override
+    public String target() {
+        return glob;
+    }
+
+    @Override
+    public String targetType() {
+        return "glob";
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/target/MinionList.java
@@ -1,0 +1,32 @@
+package com.suse.saltstack.netapi.datatypes.target;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Target for specifying a list of minions.
+ */
+public class MinionList implements Target<List<String>> {
+
+    private final java.util.List<String> targets;
+
+
+    public MinionList(List<String> targets) {
+        this.targets = targets;
+    }
+
+    public MinionList(String... targets) {
+        this(Arrays.asList(targets));
+    }
+
+    @Override
+    public List<String> target() {
+        return targets;
+    }
+
+    @Override
+    public String targetType() {
+        return "list";
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/target/NodeGroup.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/target/NodeGroup.java
@@ -1,0 +1,24 @@
+package com.suse.saltstack.netapi.datatypes.target;
+
+/**
+ * Target for referencing a nodegroup.
+ */
+public class NodeGroup implements Target<String> {
+
+    private final String nodegroup;
+
+    public NodeGroup(String nodegroup) {
+        this.nodegroup = nodegroup;
+    }
+
+    @Override
+    public String target() {
+        return nodegroup;
+    }
+
+    @Override
+    public String targetType() {
+        return "nodegroup";
+    }
+
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/target/Target.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/target/Target.java
@@ -1,0 +1,15 @@
+package com.suse.saltstack.netapi.datatypes.target;
+
+/**
+ * Target interface for specifying a group of minions.
+ *
+ * @param <T> Type of tgt property when making a request
+ */
+public interface Target<T> {
+
+    T target();
+
+    String targetType();
+
+}
+

--- a/src/main/java/com/suse/saltstack/netapi/utils/ClientUtils.java
+++ b/src/main/java/com/suse/saltstack/netapi/utils/ClientUtils.java
@@ -1,5 +1,7 @@
 package com.suse.saltstack.netapi.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
@@ -16,6 +18,9 @@ import java.util.Scanner;
  * Utilities for {@link SaltStackClient}.
  */
 public class ClientUtils {
+
+
+    private static final Gson GSON = new GsonBuilder().create();
 
     /**
      * Quietly close a given stream, suppressing exceptions.
@@ -60,13 +65,13 @@ public class ClientUtils {
      *
      * @return JsonObject filled with kwargs and args.
      */
-    public static JsonObject makeJsonData(Map<String, String> props,
+    public static JsonObject makeJsonData(Map<String, Object> props,
             Map<String, String> kwargs, List<String> args) {
         final JsonObject json = new JsonObject();
 
         if (props != null) {
-            for (Map.Entry<String, String> prop : props.entrySet()) {
-                json.addProperty(prop.getKey(), prop.getValue());
+            for (Map.Entry<String, Object> prop : props.entrySet()) {
+                json.add(prop.getKey(), GSON.toJsonTree(prop.getValue()));
             }
         }
 

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
+import com.suse.saltstack.netapi.datatypes.target.Glob;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.exception.SaltUserUnauthorizedException;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -193,7 +194,8 @@ public class SaltStackClientTest {
         };
 
         Map<String, Object> retvals =
-                client.run("user", "pass", PAM, "local", "*", "pkg.install", args, kwargs);
+                client.run("user", "pass", PAM, "local", new Glob(),
+                "pkg.install", args, kwargs);
 
         verify(1, postRequestedFor(urlEqualTo("/run"))
                 .withHeader("Accept", equalTo("application/json"))
@@ -248,7 +250,7 @@ public class SaltStackClientTest {
         };
 
         Future<Map<String, Object>> future = client.runAsync("user", "pass",
-                PAM, "local", "*", "pkg.install", args, kwargs);
+                PAM, "local", new Glob(), "pkg.install", args, kwargs);
         Map<String, Object> retvals = future.get();
 
         verify(1, postRequestedFor(urlEqualTo("/run"))
@@ -482,7 +484,7 @@ public class SaltStackClientTest {
             }
         };
 
-        ScheduledJob job = client.startCommand("*", "pkg.install", args, kwargs);
+        ScheduledJob job = client.startCommand(new Glob(), "pkg.install", args, kwargs);
 
         verify(1, postRequestedFor(urlEqualTo("/minions"))
                 .withHeader("Accept", equalTo("application/json"))
@@ -554,8 +556,8 @@ public class SaltStackClientTest {
             }
         };
 
-        Future<ScheduledJob> future = client.startCommandAsync("*", "pkg.install", args,
-                kwargs);
+        Future<ScheduledJob> future = client.startCommandAsync(new Glob(), "pkg.install",
+                args, kwargs);
         ScheduledJob job = future.get();
 
         verify(1, postRequestedFor(urlEqualTo("/minions"))

--- a/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
@@ -91,7 +91,7 @@ public class ClientUtilsTest {
         arg.add(new JsonPrimitive("bar"));
         expected.add("arg", arg);
 
-        Map<String, String> props = new LinkedHashMap<String, String>() {
+        Map<String, Object> props = new LinkedHashMap<String, Object>() {
             {
                 put("tgt", "*");
                 put("fun", "test.ping");

--- a/src/test/resources/minions_request.json
+++ b/src/test/resources/minions_request.json
@@ -1,5 +1,6 @@
 [
   {
+    "expr_form": "glob",
     "tgt": "*",
     "fun": "pkg.install",
     "arg": ["i3"],

--- a/src/test/resources/run_request.json
+++ b/src/test/resources/run_request.json
@@ -4,6 +4,7 @@
     "password": "pass",
     "eauth": "pam",
     "client": "local",
+    "expr_form": "glob",
     "tgt": "*",
     "fun": "pkg.install",
     "arg": ["i3"],


### PR DESCRIPTION
This adds initial support for `expr_form` which addresses #82.

Here is a little snippet i used for testing.

```java
        SaltStackClient client = new SaltStackClient(URI.create("http://172.17.0.19:8000"));
        client.getConfig().put(ClientConfig.SOCKET_TIMEOUT, 0);
        Map<String, Object> result =  client.run("salt", "", AuthModule.AUTO, "local", new NodeGroup("min123"), "test.ping", new ArrayList<>(), new HashMap<>());
        result.forEach((key, value) -> {
            System.out.println(key + " -> " + value);
        });

        Token token = client.login("salt", "", AuthModule.AUTO);

        ScheduledJob job = client.startCommand(new MinionList("minion1", "minion4"), "test.ping", new ArrayList<>(), new HashMap<>());
        System.out.println("Job ID: "+ job.getJid());
        job.getMinions().forEach(System.out::println);
        Map<String, Object> result2 = client.getJobResult(job);
        result2.forEach((key, value) -> {
            System.out.println(key + " -> " + value);
        });

```