### PR TITLE
{WIP} Add pending jobs to JID result set

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -14,10 +14,13 @@ import com.suse.saltstack.netapi.datatypes.target.Target;
 import com.suse.saltstack.netapi.event.EventStream;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
+import com.suse.saltstack.netapi.results.Info;
+import com.suse.saltstack.netapi.results.JobState;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.utils.ClientUtils;
 
 import java.net.URI;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -327,7 +330,19 @@ public class SaltStackClient {
                 .getResult();
 
         // A list with one element is returned, we take the first
-        return result.getResult().get(0);
+        Map<String, Object> ret = result.getResult().get(0);
+        List<Info> result_info = result.getInfo();
+
+        if (result_info != null) {
+            // add all pending results
+            HashSet<String> minions = result_info.get(0).getMinions();
+            minions.removeAll(ret.keySet());
+
+            for (String pending_minion : minions)
+                ret.put(pending_minion, JobState.PENDING);
+        }
+
+        return ret;
     }
 
     /**

--- a/src/main/java/com/suse/saltstack/netapi/results/Info.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/Info.java
@@ -1,0 +1,15 @@
+package com.suse.saltstack.netapi.results;
+
+import java.util.HashSet;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Info {
+
+    @SerializedName("Minions")
+    private final HashSet<String> minions = new HashSet<>();
+
+    public HashSet<String> getMinions() {
+        return minions;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/results/JobState.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/JobState.java
@@ -1,0 +1,5 @@
+package com.suse.saltstack.netapi.results;
+
+public enum JobState {
+    PENDING;
+}

--- a/src/main/java/com/suse/saltstack/netapi/results/Result.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/Result.java
@@ -2,6 +2,8 @@ package com.suse.saltstack.netapi.results;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 /**
  * Represents a SaltStack result.
  *
@@ -11,6 +13,7 @@ public class Result<T> {
 
     @SerializedName("return")
     private T result;
+    private List<Info> info;
 
     /**
      * Returns the value of this result.
@@ -19,5 +22,17 @@ public class Result<T> {
      */
     public T getResult() {
         return result;
+    }
+
+    /**
+     * Returns ancillary information about this result
+     *
+     * @return Ancillary information, or null if not available.
+     */
+    public List<Info> getInfo() {
+        if (info == null || info.isEmpty())
+            return null;
+
+        return info;
     }
 }

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -15,6 +15,7 @@ import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.utils.ClientUtils;
+import com.suse.saltstack.netapi.results.JobState;
 
 import static com.suse.saltstack.netapi.config.ClientConfig.SOCKET_TIMEOUT;
 import static com.suse.saltstack.netapi.AuthModule.PAM;
@@ -83,6 +84,8 @@ public class SaltStackClientTest {
             SaltStackClientTest.class.getResourceAsStream("/keys_response.json"));
     static final String JSON_JOBS_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/jobs_response.json"));
+    static final String JSON_JOBS_RESPONSE_PENDING = ClientUtils.streamToString(
+            SaltStackClientTest.class.getResourceAsStream("/jobs_response_pending.json"));
     static final String JSON_JOBS_INVALID_START_TIME_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream(
             "/jobs_response_invalid_start_time.json"));
@@ -703,6 +706,21 @@ public class SaltStackClientTest {
         verify(1, getRequestedFor(urlEqualTo("/jobs"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));
+    }
+
+    @Test
+    public void testJobsPending() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_RESPONSE_PENDING)));
+
+        Map<String, Object> results = client.getJobResult("some-job-id");
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertEquals(JobState.PENDING, results.get("mira"));
     }
 
     @Test

--- a/src/test/resources/jobs_response_pending.json
+++ b/src/test/resources/jobs_response_pending.json
@@ -1,0 +1,22 @@
+{
+   "info" : [
+      {
+         "jid" : "20150806165513400200",
+         "Target-type" : "glob",
+         "Function" : "cmd.run",
+         "StartTime" : "2015, Aug 06 16:55:13.400200",
+         "Arguments" : [
+            "sleep 30; echo testing"
+         ],
+         "Minions" : [
+            "mira"
+         ],
+         "User" : "adamm",
+         "Target" : "*",
+         "Result" : {}
+      }
+   ],
+   "return" : [
+      {}
+   ]
+}


### PR DESCRIPTION
Fixes: #83 

This is work-in-progress. I would appreciate some feedback since this issue can be fixed in many ways.

The approach in this patch adds JobsState.PENDING enum that is artificially added to results set for minions that have yet to return. This may be a little blunt. API is not changed, but user now has to check if job is pending before processing minion's output.

An alternative is to parse `info` and disregard `return`. `info["Result"]` seems to contain the same data as in `return`, though in slightly different order. Returning Info instead of a result map would definitely result in API changes, but it would allow for much more flexible interface for job results.

What do you guys think?
