### PR TITLE
Correct order of some unit tests assertEquals() parameters

### DIFF
--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -127,10 +127,10 @@ public class SaltStackClientTest {
                 .withRequestBody(equalToJson(JSON_LOGIN_REQUEST)));
 
         assertEquals("Token mismatch",
-                token.getToken(), "f248284b655724ca8a86bcab4b8df608ebf5b08b");
-        assertEquals("EAuth mismatch", token.getEauth(), "auto");
-        assertEquals("User mismatch", token.getUser(), "user");
-        assertEquals("Perms mismatch", token.getPerms(), Arrays.asList(".*", "@wheel"));
+                "f248284b655724ca8a86bcab4b8df608ebf5b08b", token.getToken());
+        assertEquals("EAuth mismatch", "auto", token.getEauth());
+        assertEquals("User mismatch", "user", token.getUser());
+        assertEquals("Perms mismatch", Arrays.asList(".*", "@wheel"), token.getPerms());
     }
 
     @Test(expected = SaltUserUnauthorizedException.class)
@@ -158,10 +158,10 @@ public class SaltStackClientTest {
                 .withRequestBody(equalToJson(JSON_LOGIN_REQUEST)));
 
         assertEquals("Token mismatch",
-                token.getToken(), "f248284b655724ca8a86bcab4b8df608ebf5b08b");
-        assertEquals("EAuth mismatch", token.getEauth(), "auto");
-        assertEquals("User mismatch", token.getUser(), "user");
-        assertEquals("Perms mismatch", token.getPerms(), Arrays.asList(".*", "@wheel"));
+                "f248284b655724ca8a86bcab4b8df608ebf5b08b", token.getToken());
+        assertEquals("EAuth mismatch", "auto", token.getEauth());
+        assertEquals("User mismatch", "user", token.getUser());
+        assertEquals("Perms mismatch", Arrays.asList(".*", "@wheel"), token.getPerms());
     }
 
     @Test(expected = ExecutionException.class)
@@ -228,7 +228,7 @@ public class SaltStackClientTest {
 
         assertNotNull(retvals);
         assertTrue(retvals.containsKey("minion-1"));
-        assertEquals(retvals.get("minion-1"), expected);
+        assertEquals(expected, retvals.get("minion-1"));
     }
 
     @Test
@@ -284,7 +284,7 @@ public class SaltStackClientTest {
 
         assertNotNull(retvals);
         assertTrue(retvals.containsKey("minion-1"));
-        assertEquals(retvals.get("minion-1"), expected);
+        assertEquals(expected, retvals.get("minion-1"));
     }
 
     @Test
@@ -492,8 +492,8 @@ public class SaltStackClientTest {
                 .withRequestBody(equalToJson(JSON_START_COMMAND_REQUEST)));
 
         assertNotNull(job);
-        assertEquals(job.getJid(), "20150211105524392307");
-        assertEquals(job.getMinions(), Arrays.asList("myminion"));
+        assertEquals("20150211105524392307", job.getJid());
+        assertEquals(Arrays.asList("myminion"), job.getMinions());
     }
 
     @Test
@@ -535,7 +535,7 @@ public class SaltStackClientTest {
 
         assertNotNull(retvals);
         assertTrue(retvals.containsKey("minion-1"));
-        assertEquals(retvals.get("minion-1"), expected);
+        assertEquals(expected, retvals.get("minion-1"));
     }
 
     @Test
@@ -566,8 +566,8 @@ public class SaltStackClientTest {
                 .withRequestBody(equalToJson(JSON_START_COMMAND_REQUEST)));
 
         assertNotNull(job);
-        assertEquals(job.getJid(), "20150211105524392307");
-        assertEquals(job.getMinions(), Arrays.asList("myminion"));
+        assertEquals("20150211105524392307", job.getJid());
+        assertEquals(Arrays.asList("myminion"), job.getMinions());
     }
 
     @Test

--- a/src/test/java/com/suse/saltstack/netapi/config/ClientConfigTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/config/ClientConfigTest.java
@@ -17,26 +17,26 @@ public class ClientConfigTest {
         Key<Integer> key = PROXY_PORT;
 
         assertEquals("New empty config should return defaultValue",
-                config.get(key), key.defaultValue);
+                key.defaultValue, config.get(key));
 
         Integer newValue = 123;
         config.put(key, newValue);
-        assertEquals("Should return the new configured value", config.get(key), newValue);
+        assertEquals("Should return the new configured value", newValue, config.get(key));
 
         config.put(key, key.defaultValue);
         assertEquals("Should return the new configured value",
-                config.get(key), key.defaultValue);
+                key.defaultValue, config.get(key));
 
         config.put(key, newValue);
-        assertEquals("Should return the new configured value", config.get(key), newValue);
+        assertEquals("Should return the new configured value", newValue, config.get(key));
         config.put(key, null);
         assertEquals("Should return the default value after putting in null",
                 config.get(key), key.defaultValue);
 
         config.put(key, newValue);
-        assertEquals("Should return the new configured value", config.get(key), newValue);
+        assertEquals("Should return the new configured value", newValue, config.get(key));
         config.remove(key);
         assertEquals("Should return the default value after removing the key",
-                config.get(key), key.defaultValue);
+                key.defaultValue, config.get(key));
     }
 }

--- a/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/utils/ClientUtilsTest.java
@@ -59,7 +59,7 @@ public class ClientUtilsTest {
         InputStream is = ClientUtils.stringToStream(TEST_STRING);
         try (Scanner scanner = new Scanner(is)) {
             String result = scanner.nextLine();
-            assertEquals("Result doesn't match test string", result, TEST_STRING);
+            assertEquals("Result doesn't match test string", TEST_STRING, result);
         }
     }
 
@@ -68,7 +68,7 @@ public class ClientUtilsTest {
         final String TEST_STRING = "SUSE";
         String result = ClientUtils.streamToString(
                 new ByteArrayInputStream(TEST_STRING.getBytes()));
-        assertEquals("Result doesn't match test string", result, TEST_STRING);
+        assertEquals("Result doesn't match test string", TEST_STRING, result);
     }
 
     @Test


### PR DESCRIPTION
The correct order is assertEquals(expected, actual) and some unit
tests were using reverse order. Using incorrect order makes any test
failure messages somewhat confusing.