### PR TITLE
Improve job result handling

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -14,6 +14,7 @@ import com.suse.saltstack.netapi.datatypes.target.Target;
 import com.suse.saltstack.netapi.event.EventStream;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
+import com.suse.saltstack.netapi.results.ResultInfoSet;
 import com.suse.saltstack.netapi.results.Result;
 import com.suse.saltstack.netapi.utils.ClientUtils;
 
@@ -328,6 +329,18 @@ public class SaltStackClient {
 
         // A list with one element is returned, we take the first
         return result.getResult().get(0);
+    }
+
+    public ResultInfoSet getJobResultInfo(final ScheduledJob job)
+            throws SaltStackException {
+
+        return getJobResultInfo(job.getJid());
+    }
+
+    public ResultInfoSet getJobResultInfo(final String job) throws SaltStackException {
+        return connectionFactory
+                .create("/jobs/" + job, JsonParser.JOB_RESULTS, config)
+                .getResult();
     }
 
     /**

--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -16,6 +16,7 @@ import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
 import com.suse.saltstack.netapi.results.ResultInfoSet;
 import com.suse.saltstack.netapi.results.Result;
+import com.suse.saltstack.netapi.results.ResultInfo;
 import com.suse.saltstack.netapi.utils.ClientUtils;
 
 import java.net.URI;
@@ -305,11 +306,10 @@ public class SaltStackClient {
      * {@code GET /job/<job-id>}
      *
      * @param job {@link ScheduledJob} object representing scheduled job
-     * @return Map key: minion id, value: command result from that minion
+     * @return {@link ResultInfoSet} representing result set from minions
      * @throws SaltStackException if anything goes wrong
      */
-    public Map<String, Object> getJobResult(final ScheduledJob job)
-            throws SaltStackException {
+    public ResultInfoSet getJobResult(final ScheduledJob job) throws SaltStackException {
         return getJobResult(job.getJid());
     }
 
@@ -319,25 +319,10 @@ public class SaltStackClient {
      * {@code GET /job/<job-id>}
      *
      * @param job String representing scheduled job
-     * @return Map key: minion id, value: command result from that minion
+     * @return {@link ResultInfoSet} representing result set from minions
      * @throws SaltStackException if anything goes wrong
      */
-    public Map<String, Object> getJobResult(final String job) throws SaltStackException {
-        Result<List<Map<String, Object>>> result = connectionFactory
-                .create("/jobs/" + job, JsonParser.RETVALS, config)
-                .getResult();
-
-        // A list with one element is returned, we take the first
-        return result.getResult().get(0);
-    }
-
-    public ResultInfoSet getJobResultInfo(final ScheduledJob job)
-            throws SaltStackException {
-
-        return getJobResultInfo(job.getJid());
-    }
-
-    public ResultInfoSet getJobResultInfo(final String job) throws SaltStackException {
+    public ResultInfoSet getJobResult(final String job) throws SaltStackException {
         return connectionFactory
                 .create("/jobs/" + job, JsonParser.JOB_RESULTS, config)
                 .getResult();
@@ -385,7 +370,7 @@ public class SaltStackClient {
      * @return Map key: minion id, value: command result from that minion
      * @throws SaltStackException if anything goes wrong
      */
-    public <T> Map<String, Object> run(final String username, final String password,
+    public <T> ResultInfo run(final String username, final String password,
             final AuthModule eauth, final String client, final Target<T> target,
             final String function, List<String> args, Map<String, String> kwargs)
             throws SaltStackException {
@@ -404,12 +389,12 @@ public class SaltStackClient {
         JsonArray jsonArray = new JsonArray();
         jsonArray.add(ClientUtils.makeJsonData(props, kwargs, args));
 
-        Result<List<Map<String, Object>>> result = connectionFactory
-                .create("/run", JsonParser.RETVALS, config)
+        ResultInfoSet result = connectionFactory
+                .create("/run", JsonParser.JOB_RESULTS, config)
                 .getResult(jsonArray.toString());
 
         // A list with one element is returned, we take the first
-        return result.getResult().get(0);
+        return result.get(0);
     }
 
     /**
@@ -427,7 +412,7 @@ public class SaltStackClient {
      * @param kwargs map containing keyword arguments
      * @return Future containing Map key: minion id, value: command result from that minion
      */
-    public <T> Future<Map<String, Object>> runAsync(final String username,
+    public <T> Future<ResultInfo> runAsync(final String username,
             final String password, final AuthModule eauth, final String client,
             final Target<T> target, final String function, final List<String> args,
             final Map<String, String> kwargs) {

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -52,8 +52,6 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<List<Map<String, Job>>>>(){});
     public static final JsonParser<ResultInfoSet> JOB_RESULTS =
             new JsonParser<>(new TypeToken<ResultInfoSet>(){});
-    public static final JsonParser<Result<List<Map<String, Object>>>> RETVALS =
-            new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Result<List<Map<String, Map<String, Object>>>>> RETMAPS =
             new JsonParser<>(
             new TypeToken<Result<List<Map<String, Map<String, Object>>>>>(){});

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -22,6 +22,7 @@ import com.suse.saltstack.netapi.datatypes.cherrypy.HttpServer;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.exception.ParsingException;
 import com.suse.saltstack.netapi.results.Result;
+import com.suse.saltstack.netapi.results.ResultInfoSet;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -49,6 +50,8 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<List<ScheduledJob>>>(){});
     public static final JsonParser<Result<List<Map<String, Job>>>> JOBS =
             new JsonParser<>(new TypeToken<Result<List<Map<String, Job>>>>(){});
+    public static final JsonParser<ResultInfoSet> JOB_RESULTS =
+            new JsonParser<>(new TypeToken<ResultInfoSet>(){});
     public static final JsonParser<Result<List<Map<String, Object>>>> RETVALS =
             new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Result<List<Map<String, Map<String, Object>>>>> RETMAPS =

--- a/src/main/java/com/suse/saltstack/netapi/results/ResultInfo.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/ResultInfo.java
@@ -1,0 +1,147 @@
+package com.suse.saltstack.netapi.results;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.suse.saltstack.netapi.parser.JsonParser;
+
+/**
+ *
+ * Represents the SaltStack's result information structure.
+ *
+ */
+
+public class ResultInfo {
+
+    @SerializedName("Function")
+    private String function;
+
+    @SerializedName("StartTime")
+    @JsonAdapter(JsonParser.JobStartTimeJsonAdapter.class)
+    private Date startTime;
+
+    @SerializedName("Arguments")
+    private List<Object> arguments;
+
+    @SerializedName("Minions")
+    private final HashSet<String> minions = new HashSet<>();
+
+    @SerializedName("User")
+    private String user;
+
+    @SerializedName("Target")
+    private String target;
+
+    @SerializedName("Result")
+    private HashMap<String, Result<Object>> rawResults;
+    private transient final HashMap<String, Object> resultsCache = new HashMap<>();
+
+    /**
+     * Returns a list of arguments supplied function.
+     *
+     * @return list of Objects
+     */
+    public List<Object> getArguments() {
+        return arguments;
+    }
+
+    /**
+     * Returns function name.
+     *
+     * @return function name
+     */
+    public String getFunction() {
+        return function;
+    }
+
+    /**
+     * Returns set of minions this job was submitted to.
+     *
+     * @return minion set
+     */
+    public Set<String> getMinions() {
+        return minions;
+    }
+
+    /**
+     * Returns start time of the job.
+     *
+     * @return job start date
+     */
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * Returns target of job submission.
+     *
+     * @return job submission target
+     */
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * Returns user associated with this job.
+     *
+     * @return job's user
+     */
+    public String getUser() {
+        return user;
+    }
+
+    /**
+     * Returns job's return value that is associated with supplied minion
+     * as an {@link Optional}. If a minion has not returned a response, an empty
+     * value is returned.
+     *
+     * @param minion - name of a minion
+     *
+     * @return {@link Optional} associated with the result from a given minion.
+     */
+    public Optional<Object> getResult(String minion) {
+        Result<Object> result;
+        if (rawResults == null || (result = rawResults.get(minion)) == null)
+            return Optional.<Object>empty();
+
+        return Optional.<Object>ofNullable(result.getResult());
+    }
+
+    /**
+     * Returns result map of available {@link Object} associated with each minion.
+     * Minions that have yet to return a value are not included in this mapping.
+     *
+     * @return Map&lt;String, Object&gt; of available job return values.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getResults() {
+        if (rawResults == null || resultsCache.size() == rawResults.size())
+            return resultsCache;
+
+        resultsCache.clear();
+        resultsCache.putAll(rawResults);
+        resultsCache.replaceAll(
+                (String key, Object result) -> ((Result<Object>) result).getResult());
+
+        return resultsCache;
+    }
+
+    /**
+     * Returns a set of minions that have yet to return a result.
+     *
+     * @return set of minions that have not returned a result.
+     */
+    public Set<String> getPendingMinions() {
+        HashSet<String> pend = new HashSet<>(minions);
+
+        pend.removeAll(rawResults.keySet());
+        return pend;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/results/ResultInfoSet.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/ResultInfoSet.java
@@ -1,0 +1,49 @@
+package com.suse.saltstack.netapi.results;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Holds a result set of a running job. Normally, only one result will be
+ * available.
+ */
+public class ResultInfoSet implements Iterable<ResultInfo> {
+    private List<ResultInfo> info;
+
+    /**
+     * Returns an iterator to the ResultInfo collection.
+     */
+    @Override
+    public Iterator<ResultInfo> iterator() {
+        return info.iterator();
+    }
+
+    /**
+     * Returns {@link ResultInfo} associated with a given index. Most jobs
+     * should only have 1 result structure.
+     *
+     * @param index represents index of the result.
+     * @return ResultInfo associated with the index
+     */
+    public ResultInfo get(int index) {
+        return info.get(index);
+    }
+
+    /**
+     * Returns result set size.
+     *
+     * @return result set size
+     */
+    public int size() {
+        return info.size();
+    }
+
+    /**
+     * Returns a list of all results.
+     *
+     * @return list of {@link ResultInfo}
+     */
+    public List<ResultInfo> getInfoList() {
+        return info;
+    }
+}

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -200,7 +200,7 @@ public class SaltStackClientTest {
 
         Map<String, Object> retvals =
                 client.run("user", "pass", PAM, "local", new Glob(),
-                "pkg.install", args, kwargs);
+                "pkg.install", args, kwargs).getResults();
 
         verify(1, postRequestedFor(urlEqualTo("/run"))
                 .withHeader("Accept", equalTo("application/json"))
@@ -210,21 +210,21 @@ public class SaltStackClientTest {
         Map<String, Map<String, String>> expected =
                 new LinkedHashMap<String, Map<String, String>>() {
             {
-                put("i3-wm", new LinkedHashMap<String, String>() {
+                put("i3lock", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "4.10.1-1");
+                        put("new", "2.7-1");
                         put("old", "");
                     }
                 });
-                put("i3lock", new LinkedHashMap<String, String>() {
+                put("i3", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.6-1");
+                        put("new", "4.10.3-1");
                         put("old", "");
                     }
                 });
                 put("i3status", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.9-1");
+                        put("new", "2.9-2");
                         put("old", "");
                     }
                 });
@@ -254,9 +254,9 @@ public class SaltStackClientTest {
             }
         };
 
-        Future<Map<String, Object>> future = client.runAsync("user", "pass",
+        Future<ResultInfo> future = client.runAsync("user", "pass",
                 PAM, "local", new Glob(), "pkg.install", args, kwargs);
-        Map<String, Object> retvals = future.get();
+        Map<String, Object> retvals = future.get().getResults();
 
         verify(1, postRequestedFor(urlEqualTo("/run"))
                 .withHeader("Accept", equalTo("application/json"))
@@ -266,21 +266,21 @@ public class SaltStackClientTest {
         Map<String, Map<String, String>> expected =
                 new LinkedHashMap<String, Map<String, String>>() {
             {
-                put("i3-wm", new LinkedHashMap<String, String>() {
+                put("i3lock", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "4.10.1-1");
+                        put("new", "2.7-1");
                         put("old", "");
                     }
                 });
-                put("i3lock", new LinkedHashMap<String, String>() {
+                put("i3", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.6-1");
+                        put("new", "4.10.3-1");
                         put("old", "");
                     }
                 });
                 put("i3status", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.9-1");
+                        put("new", "2.9-2");
                         put("old", "");
                     }
                 });
@@ -509,7 +509,8 @@ public class SaltStackClientTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_RUN_RESPONSE)));
 
-        Map<String, Object> retvals = client.getJobResult("some-job-id");
+        Map<String, Object> retvals = client.getJobResult("some-job-id")
+                .get(0).getResults();
 
         verify(1, getRequestedFor(urlEqualTo("/jobs/some-job-id"))
                 .withHeader("Accept", equalTo("application/json")));
@@ -517,21 +518,21 @@ public class SaltStackClientTest {
         Map<String, Map<String, String>> expected =
                 new LinkedHashMap<String, Map<String, String>>() {
             {
-                put("i3-wm", new LinkedHashMap<String, String>() {
+                put("i3lock", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "4.10.1-1");
+                        put("new", "2.7-1");
                         put("old", "");
                     }
                 });
-                put("i3lock", new LinkedHashMap<String, String>() {
+                put("i3", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.6-1");
+                        put("new", "4.10.3-1");
                         put("old", "");
                     }
                 });
                 put("i3status", new LinkedHashMap<String, String>() {
                     {
-                        put("new", "2.9-1");
+                        put("new", "2.9-2");
                         put("old", "");
                     }
                 });
@@ -718,13 +719,12 @@ public class SaltStackClientTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_JOBS_RESPONSE_PENDING)));
 
-        ResultInfoSet resultSet = client.getJobResultInfo("some-job-id");
+        ResultInfoSet resultSet = client.getJobResult("some-job-id");
         assertEquals(1, resultSet.size());
         ResultInfo results = resultSet.get(0);
 
-        HashSet<String> pendingMinions = new HashSet<String>() {
-            { add("mira"); }
-        };
+        HashSet<String> pendingMinions = new HashSet<String>();
+        pendingMinions.add("mira");
 
         assertNotNull(results);
         assertEquals(0, results.getResults().size());

--- a/src/test/resources/jobs_response_pending.json
+++ b/src/test/resources/jobs_response_pending.json
@@ -1,0 +1,22 @@
+{
+   "info" : [
+      {
+         "jid" : "20150806165513400200",
+         "Target-type" : "glob",
+         "Function" : "cmd.run",
+         "StartTime" : "2015, Aug 06 16:55:13.400200",
+         "Arguments" : [
+            "sleep 30; echo testing"
+         ],
+         "Minions" : [
+            "mira"
+         ],
+         "User" : "adamm",
+         "Target" : "*",
+         "Result" : {}
+      }
+   ],
+   "return" : [
+      {}
+   ]
+}

--- a/src/test/resources/run_response.json
+++ b/src/test/resources/run_response.json
@@ -1,20 +1,59 @@
 {
-  "return": [
-    {
-      "minion-1": {
-        "i3-wm": {
-          "new": "4.10.1-1",
-          "old": ""
-        },
-        "i3lock": {
-          "new": "2.6-1",
-          "old": ""
-        },
-        "i3status": {
-          "new": "2.9-1",
-          "old": ""
-        }
+   "return" : [
+      {
+         "minion-1" : {
+            "i3status" : {
+               "old" : "",
+               "new" : "2.9-2"
+            },
+            "i3" : {
+               "old" : "",
+               "new" : "4.10.3-1"
+            },
+            "i3lock" : {
+               "new" : "2.7-1",
+               "old" : ""
+            }
+         }
       }
-    }
-  ]
+   ],
+   "info" : [
+      {
+         "Minions" : [
+            "minion-1"
+         ],
+         "Function" : "pkg.install",
+         "Arguments" : [
+            "i3",
+            {
+               "__kwarg__" : true,
+               "sysupgrade" : "false",
+               "refresh" : "true"
+            }
+         ],
+         "Target" : "*",
+         "jid" : "20150810200316696112",
+         "Result" : {
+            "minion-1" : {
+               "return" : {
+                  "i3lock" : {
+                     "old" : "",
+                     "new" : "2.7-1"
+                  },
+                  "i3" : {
+                     "old" : "",
+                     "new" : "4.10.3-1"
+                  },
+                  "i3status" : {
+                     "old" : "",
+                     "new" : "2.9-2"
+                  }
+               }
+            }
+         },
+         "User" : "adamm",
+         "Target-type" : "glob",
+         "StartTime" : "2015, Aug 10 20:03:16.696112"
+      }
+   ]
 }


### PR DESCRIPTION
These two patches attempt to address the "pending job" enhancement (#83)

The first patch simply adds capability to parse the `info` structure. This structure contains duplicate minion result set. I've included a convenience function to return result set in the same format as the old `return` structure.

The second patch replaces old job result and returns ResultInfoSet instead of a simple map. The simple map is still available from within the ResultInfo class.