### PR TITLE
Basic parsing of events

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Event.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Event.java
@@ -1,0 +1,28 @@
+package com.suse.saltstack.netapi.datatypes;
+
+import java.util.HashMap;
+
+/**
+ * Parse events into objects.
+ */
+public class Event {
+
+    private String tag;
+    private HashMap<String, Object> data;
+
+    /**
+     * Return this event's tag.
+     * @return the tag
+     */
+    public String getTag() {
+        return tag;
+    }
+
+    /**
+     * Return this event's data.
+     * @return the data
+     */
+    public HashMap<String, Object> getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Event.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Event.java
@@ -1,6 +1,6 @@
 package com.suse.saltstack.netapi.datatypes;
 
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Parse events into objects.
@@ -8,7 +8,7 @@ import java.util.HashMap;
 public class Event {
 
     private String tag;
-    private HashMap<String, Object> data;
+    private Map<String, Object> data;
 
     /**
      * Return this event's tag.
@@ -22,7 +22,7 @@ public class Event {
      * Return this event's data.
      * @return the data
      */
-    public HashMap<String, Object> getData() {
+    public Map<String, Object> getData() {
         return data;
     }
 }

--- a/src/main/java/com/suse/saltstack/netapi/event/EventListener.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventListener.java
@@ -1,16 +1,17 @@
 package com.suse.saltstack.netapi.event;
 
+import com.suse.saltstack.netapi.datatypes.Event;
+
 /**
  * Defines a client notification interface for events stream.
  */
 public interface EventListener {
 
     /**
-     * Notify the listener of a new event stream event.  Returned data is a {@link String}
-     * in JSON format.
-     * @param event Return a JSON representation of the latest stream event.
+     * Notify the listener of a new event. Returned data is a {@link Event} object.
+     * @param event object representation of the latest stream event
      */
-    void notify(String event);
+    void notify(Event event);
 
     /**
      * Notify the listener that the backing event stream was closed.  Listener may

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -1,7 +1,9 @@
 package com.suse.saltstack.netapi.event;
 
 import com.suse.saltstack.netapi.config.ClientConfig;
+import com.suse.saltstack.netapi.datatypes.Event;
 import com.suse.saltstack.netapi.exception.SaltStackException;
+import com.suse.saltstack.netapi.parser.JsonParser;
 
 import javax.websocket.ClientEndpoint;
 import javax.websocket.CloseReason;
@@ -188,16 +190,17 @@ public class EventStream implements AutoCloseable {
     }
 
     /**
-     * On each event received on the WebSocket,
-     * notify each listener with the event received.
+     * Notify listeners on each event received on the WebSocket.
      *
-     * @param event The message received on this WebSocket.
+     * @param message The message received on this WebSocket
      */
     @OnMessage
-    public void onMessage(String event) {
-        if (event != null && !event.equals("server received message")) {
+    public void onMessage(String message) {
+        if (message != null && !message.equals("server received message")) {
+            // Salt API adds a "data: " prefix that we need to ignore
+            Event event = JsonParser.EVENTS.parse(message.substring(6));
             synchronized (listeners) {
-                listeners.stream().forEach(l -> l.notify(event.trim()));
+                listeners.stream().forEach(l -> l.notify(event));
             }
         }
     }

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -13,6 +13,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.suse.saltstack.netapi.datatypes.Arguments;
+import com.suse.saltstack.netapi.datatypes.Event;
 import com.suse.saltstack.netapi.datatypes.Job;
 import com.suse.saltstack.netapi.datatypes.Keys;
 import com.suse.saltstack.netapi.datatypes.ScheduledJob;
@@ -60,6 +61,8 @@ public class JsonParser<T> {
             new JsonParser<>(new TypeToken<Result<Keys>>(){});
     public static final JsonParser<Map<String, Object>> MAP =
             new JsonParser<>(new TypeToken<Map<String, Object>>(){});
+    public static final JsonParser<Event> EVENTS =
+            new JsonParser<>(new TypeToken<Event>(){});
 
     private final TypeToken<T> type;
     private final Gson gson;
@@ -89,6 +92,15 @@ public class JsonParser<T> {
 
         // Parse result type from the returned JSON
         return gson.fromJson(streamReader, type.getType());
+    }
+
+    /**
+     * Parse JSON given as string.
+     * @param jsonString JSON input given as string
+     * @return The parsed object
+     */
+    public T parse(String jsonString) {
+        return gson.fromJson(jsonString, type.getType());
     }
 
     /**

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -1,6 +1,8 @@
 package com.suse.saltstack.netapi.event;
 
 import com.suse.saltstack.netapi.config.ClientConfig;
+import com.suse.saltstack.netapi.datatypes.Event;
+
 import org.glassfish.tyrus.server.Server;
 import org.junit.After;
 import org.junit.Assert;
@@ -105,8 +107,9 @@ public class TyrusWebSocketEventsTest {
 
             latch.await(30, TimeUnit.SECONDS);
             synchronized (eventContentClient.events) {
-                Assert.assertTrue(eventContentClient.events.get(1)
-                        .contains("\"jid\": \"20150505113307407682\""));
+                Event event = eventContentClient.events.get(1);
+                Assert.assertTrue(event.getData().containsKey("jid"));
+                Assert.assertEquals("20150505113307407682", event.getData().get("jid"));
             }
             streamEvents.close();
         }
@@ -196,7 +199,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void notify(String event) {
+        public void notify(Event event) {
             counter++;
             if (counter == targetCount) {
                 latch.countDown();
@@ -212,7 +215,7 @@ public class TyrusWebSocketEventsTest {
      * Event listener client used for testing.
      */
     private class EventContentClient implements EventListener {
-        List<String> events = new ArrayList<>();
+        List<Event> events = new ArrayList<>();
         CountDownLatch latch;
 
         public EventContentClient(CountDownLatch latchIn) {
@@ -220,7 +223,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void notify(String event) {
+        public void notify(Event event) {
             synchronized (events) {
                 events.add(event);
                 if (events.size() > 2) {
@@ -239,7 +242,7 @@ public class TyrusWebSocketEventsTest {
      */
     private class SimpleEventListenerClient implements EventListener {
         @Override
-        public void notify(String event) {
+        public void notify(Event event) {
         }
 
         @Override
@@ -258,7 +261,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void notify(String event) {
+        public void notify(Event event) {
             this.latch.countDown();
         }
 

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -111,7 +111,6 @@ public class TyrusWebSocketEventsTest {
                 Assert.assertTrue(event.getData().containsKey("jid"));
                 Assert.assertEquals("20150505113307407682", event.getData().get("jid"));
             }
-            streamEvents.close();
         }
     }
 

--- a/src/test/java/com/suse/saltstack/netapi/event/WebSocketServerSalt.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/WebSocketServerSalt.java
@@ -37,7 +37,7 @@ public class WebSocketServerSalt {
                 session.getBasicRemote().sendText(s);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            System.out.println("IOException: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
This patch brings in basic parsing of events into objects. So far we are only separating an event's `tag` from its `data` though. This is already very helpful in order to filter the event stream for interesting events. Apart from that there is two small commits affecting the event stream tests. Please have a look, @lucidd, thank you!