### PR TITLE
Add timezone support for parsing StartTime

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/calls/runner/Jobs.java
+++ b/src/main/java/com/suse/saltstack/netapi/calls/runner/Jobs.java
@@ -1,6 +1,5 @@
 package com.suse.saltstack.netapi.calls.runner;
 
-import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.suse.saltstack.netapi.calls.Data;
@@ -8,7 +7,7 @@ import com.suse.saltstack.netapi.calls.LocalAsyncResult;
 import com.suse.saltstack.netapi.calls.RunnerAsyncResult;
 import com.suse.saltstack.netapi.calls.RunnerCall;
 import com.suse.saltstack.netapi.calls.WheelAsyncResult;
-import com.suse.saltstack.netapi.parser.JsonParser;
+import com.suse.saltstack.netapi.datatypes.StartTime;
 import com.suse.saltstack.netapi.results.Result;
 
 import java.lang.reflect.Type;
@@ -18,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
 
@@ -38,8 +38,7 @@ public class Jobs {
         private String jid;
 
         @SerializedName("StartTime")
-        @JsonAdapter(JsonParser.JobStartTimeJsonAdapter.class)
-        private Date startTime;
+        private StartTime startTime;
 
         @SerializedName("Arguments")
         private List<Object> arguments;
@@ -64,8 +63,12 @@ public class Jobs {
             return jid;
         }
 
+        public Date getStartTime(TimeZone tz) {
+            return startTime == null ? null : startTime.getDate(tz);
+        }
+
         public Date getStartTime() {
-            return startTime;
+            return startTime == null ? null : startTime.getDate();
         }
 
         public List<Object> getArguments() {

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/Job.java
@@ -1,21 +1,14 @@
 package com.suse.saltstack.netapi.datatypes;
 
-import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import com.suse.saltstack.netapi.parser.JsonParser;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Representation of a previously run job.
  */
 public class Job {
-
-    // StartTime example from API: "2015, Mar 04 19:28:29.724698"
-    public static final SimpleDateFormat START_TIME_FORMAT =
-            new SimpleDateFormat("yyyy, MMM dd HH:mm:ss.SSS", Locale.US);
 
     @SerializedName("Function")
     private String function;
@@ -32,12 +25,8 @@ public class Job {
     @SerializedName("Arguments")
     private Arguments arguments;
 
-    /**
-     * Please note that start time will be in salt-master time zone
-     */
     @SerializedName("StartTime")
-    @JsonAdapter(JsonParser.JobStartTimeJsonAdapter.class)
-    private Date startTime;
+    private StartTime startTime;
 
     public String getFunction() {
         return function;
@@ -59,7 +48,22 @@ public class Job {
         return arguments;
     }
 
+    /**
+     * Returns start time at a given {@link TimeZone}
+     *
+     * @param tz TimeZone of the master associated with the Job
+     * @return Date representation of the start time.
+     */
+    public Date getStartTime(TimeZone tz) {
+        return startTime == null ? null : startTime.getDate(tz);
+    }
+
+    /**
+     *  Returns start time assuming default {@link TimeZone} is Salt master's timezone.
+     *
+     * @return Date representation of the start time.
+     */
     public Date getStartTime() {
-        return startTime;
+        return startTime == null ? null : startTime.getDate();
     }
 }

--- a/src/main/java/com/suse/saltstack/netapi/datatypes/StartTime.java
+++ b/src/main/java/com/suse/saltstack/netapi/datatypes/StartTime.java
@@ -1,0 +1,80 @@
+package com.suse.saltstack.netapi.datatypes;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import com.suse.saltstack.netapi.exception.ParsingException;
+
+/**
+ * StartDate is a convenience wrapper allowing for parsing of StartDate in the
+ * timezone appropriate to a given master.
+ */
+
+public class StartTime {
+    private final String dateString;
+    private transient final Date defaultTzDate;
+
+    // StartTime example from API: "2015, Mar 04 19:28:29.724698"
+    private transient final SimpleDateFormat startJobDateFormat =
+            new SimpleDateFormat("yyyy, MMM dd HH:mm:ss.SSS", Locale.US);
+
+    public StartTime(String dateString) throws ParsingException {
+        try {
+            if (dateString != null)
+                this.defaultTzDate = startJobDateFormat.parse(dateString);
+            else
+                this.defaultTzDate = null;
+        } catch (ParseException e) {
+            throw new ParsingException(e);
+        }
+        this.dateString = dateString;
+    }
+
+    /**
+     * Returns {@link Date} representation of StartTime as parsed at a given timezone.
+     * Master does not return a timezone associated with StartTime timestamp string,
+     * therefore an explicit timezone needs to be provided for correct parsing.
+     *
+     * @param tz TimeZone associated with master.
+     * @return {@link Date} representation of StartTime at provided timezone
+     */
+    public synchronized Date getDate(TimeZone tz) {
+        if (dateString == null)
+            return null;
+
+        startJobDateFormat.setTimeZone(tz);
+        try {
+            return startJobDateFormat.parse(dateString);
+        } catch (ParseException e) {
+            // This exception should not be possible. Even when dealing with TZ DST
+            // transitions, all dates exist. Time that does not exist because of
+            // forward DST transition, get automatically forwarded during parsing.
+            throw new RuntimeException("Internal problem with Java and timezones " +
+                    dateString + " @TZ: " + tz.toString());
+        }
+    }
+
+    /**
+     * Returns {@link Date} representation of StartTime as parsed using default timezone.
+     *
+     * <p>NOTE: If master is using a different timezone than the default timezone of the
+     * user of this API, then the returned Date will be incorrect.
+     *
+     * @return {@link Date} representation of StartTime using default timezone.
+     */
+    public Date getDate() {
+        return defaultTzDate;
+    }
+
+    /**
+     * Returns a string representation of StartTime. This is the same string that is
+     * passed to the constructor.
+     */
+    @Override
+    public String toString() {
+        return dateString;
+    }
+}

--- a/src/main/java/com/suse/saltstack/netapi/results/ResultInfo.java
+++ b/src/main/java/com/suse/saltstack/netapi/results/ResultInfo.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 
-import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import com.suse.saltstack.netapi.parser.JsonParser;
+import com.suse.saltstack.netapi.datatypes.StartTime;
 
 /**
  * Represents the SaltStack's result information structure.
@@ -21,8 +21,7 @@ public class ResultInfo {
     private String function;
 
     @SerializedName("StartTime")
-    @JsonAdapter(JsonParser.JobStartTimeJsonAdapter.class)
-    private Date startTime;
+    private StartTime startTime;
 
     @SerializedName("Arguments")
     private List<Object> arguments;
@@ -70,10 +69,20 @@ public class ResultInfo {
     /**
      * Returns start time of the job.
      *
+     * @param tz - TimeZone associated with the master of this job.
      * @return job start date
      */
+    public Date getStartTime(TimeZone tz) {
+        return startTime == null ? null : startTime.getDate(tz);
+    }
+
+    /**
+     *  Returns start time assuming default {@link TimeZone} is Salt master's timezone.
+     *
+     * @return Date representation of the start time.
+     */
     public Date getStartTime() {
-        return startTime;
+        return startTime == null ? null : startTime.getDate();
     }
 
     /**

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,6 +54,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -630,6 +632,50 @@ public class SaltStackClientTest {
                 .withRequestBody(equalTo("")));
     }
 
+    @Test
+    public void testJobsDiffTz() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_JOBS_RESPONSE)));
+
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+        TimeZone defaultTz = TimeZone.getDefault();
+        TimeZone tz = null;
+
+        for (String zone : TimeZone.getAvailableIDs()) {
+            tz = TimeZone.getTimeZone(zone);
+            long diff = tz.getRawOffset() -
+                    df.getTimeZone().getRawOffset();
+
+            // Pick a TZ far enough from default to avoid possible DST issues
+            if (Math.abs(diff) > 3600000 * 3) {
+                break;
+            }
+        }
+
+        Map<String, Job> jobs = client.getJobs();
+        Job job1 = jobs.get("20150304192951636258");
+        Job job2 = jobs.get("20150304200110485012");
+
+        assertEquals(df.parse("2015-03-04 19:29:51.636"), job1.getStartTime(defaultTz));
+        assertEquals(df.parse("2015-03-04 20:01:10.485"), job2.getStartTime(defaultTz));
+        assertEquals(df.parse("2015-03-04 19:29:51.636"), job1.getStartTime());
+        assertEquals(df.parse("2015-03-04 20:01:10.485"), job2.getStartTime());
+
+        df.setTimeZone(tz);
+        assertEquals(df.parse("2015-03-04 19:29:51.636"), job1.getStartTime(tz));
+        assertEquals(df.parse("2015-03-04 20:01:10.485"), job2.getStartTime(tz));
+        assertNotEquals(job1.getStartTime(defaultTz), job1.getStartTime(tz));
+        assertNotEquals(job2.getStartTime(defaultTz), job2.getStartTime(tz));
+
+        verify(1, getRequestedFor(urlEqualTo("/jobs"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withRequestBody(equalTo("")));
+    }
+
     @Test(expected = JsonSyntaxException.class)
     public void testJobsWithInvalidStartTime() throws Exception {
         stubFor(any(urlMatching(".*"))
@@ -655,6 +701,8 @@ public class SaltStackClientTest {
         Job job2 = jobs.get("20150304200110485012");
         assertNull(job1.getStartTime());
         assertNull(job2.getStartTime());
+        assertNull(job1.getStartTime(TimeZone.getDefault()));
+        assertNull(job2.getStartTime(TimeZone.getDefault()));
         verify(1, getRequestedFor(urlEqualTo("/jobs"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withRequestBody(equalTo("")));
@@ -702,6 +750,8 @@ public class SaltStackClientTest {
         assertEquals(pendingMinions, results.getMinions());
         assertEquals(pendingMinions, results.getPendingMinions());
         assertEquals("2015-08-06 16:55:13", DATE_FORMAT.format(results.getStartTime()));
+        assertEquals("2015-08-06 16:55:13",
+                DATE_FORMAT.format(results.getStartTime(DATE_FORMAT.getTimeZone())));
 
         verify(1, getRequestedFor(urlEqualTo("/jobs/some-job-id"))
                 .withHeader("Accept", equalTo("application/json"))


### PR DESCRIPTION
This attempts to add TimeZone configuration support for master's StartTime parsing. By default, if TimeZone is unset and left as system default, there should be no performance impact.

To facilitate per-server timezone settings, parser needs to be aware of configuration. It appears that annotations are unworkable in this scenario because Gson uses reflection to to create instance for annotated types and these do not have access to JsonParser instance. No JsonParser instance, no configuration, no timezones. I've added a simple StartTime wrapper class to remove need for annotations. External API is not affected.

There appears to be no way around rebuilding a parser though. But this only affects users that have different timezone from server (master), which I'd expect to be mostly desktop applications.