### PR TITLE
Add support for salt.modules.status

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/calls/modules/Status.java
+++ b/src/main/java/com/suse/saltstack/netapi/calls/modules/Status.java
@@ -1,0 +1,108 @@
+package com.suse.saltstack.netapi.calls.modules;
+
+import com.suse.saltstack.netapi.calls.LocalCall;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * salt.modules.status
+ */
+public class Status {
+
+    private Status() { }
+
+    public static LocalCall<Map<String, Object>> allstatus() {
+        return new LocalCall<>("status.all_status", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Object>>(){});
+    }
+
+    public static LocalCall<Map<String, Object>> cpuinfo() {
+        return new LocalCall<>("status.cpuinfo", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Object>>(){});
+    }
+
+    public static LocalCall<Map<String, Object>> cpustats() {
+        return new LocalCall<>("status.cpustats", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Object>>(){});
+    }
+
+    public static LocalCall<Map<String, Object>> custom() {
+        return new LocalCall<>("status.custom", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Object>>(){});
+    }
+
+    public static LocalCall<Map<String, Map<String, Object>>> diskstats() {
+        return new LocalCall<>("status.diskstats", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Map<String, Object>>>(){});
+    }
+
+    public static LocalCall<Map<String, Map<String, Long>>> diskusage(
+            String... pathsOrFSTypes) {
+        List<Object> args = Arrays.asList((Object[]) pathsOrFSTypes);
+        return new LocalCall<>("status.diskusage", Optional.of(args), Optional.empty(),
+                new TypeToken<Map<String, Map<String, Long>>>(){});
+    }
+
+    public static LocalCall<Map<String, Double>> loadavg() {
+        return new LocalCall<>("status.loadavg", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Double>>(){});
+    }
+
+    public static LocalCall<Map<String, Map<String, Object>>> meminfo() {
+        return new LocalCall<>("status.meminfo", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Map<String, Object>>>(){});
+    }
+
+    public static LocalCall<Map<String, Map<String, Object>>> netdev() {
+        return new LocalCall<>("status.netdev", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Map<String, Object>>>(){});
+    }
+
+    public static LocalCall<Map<String, Map<String, Long>>> netstats() {
+        return new LocalCall<>("status.netstats", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Map<String, Long>>>(){});
+    }
+
+    public static LocalCall<Integer> nproc() {
+        return new LocalCall<>("status.nproc", Optional.empty(), Optional.empty(),
+                new TypeToken<Integer>(){});
+    }
+
+    public static LocalCall<String> pid(String signature) {
+        List<Object> args = new ArrayList<>();
+        args.add(signature);
+        return new LocalCall<>("status.pid", Optional.of(args), Optional.empty(),
+                new TypeToken<String>(){});
+    }
+
+    public static LocalCall<Map<Integer, Map<String, String>>> procs() {
+        return new LocalCall<>("status.procs", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<Integer, Map<String, String>>>(){});
+    }
+
+    public static LocalCall<String> uptime() {
+        return new LocalCall<>("status.uptime", Optional.empty(), Optional.empty(),
+                new TypeToken<String>(){});
+    }
+
+    public static LocalCall<String> version() {
+        return new LocalCall<>("status.version", Optional.empty(), Optional.empty(),
+                new TypeToken<String>(){});
+    }
+
+    public static LocalCall<Map<String, Long>> vmstats() {
+        return new LocalCall<>("status.vmstats", Optional.empty(), Optional.empty(),
+                new TypeToken<Map<String, Long>>(){});
+    }
+
+    public static LocalCall<List<Map<String, String>>> w() {
+        return new LocalCall<>("status.w", Optional.empty(), Optional.empty(),
+                new TypeToken<List<Map<String, String>>>(){});
+    }
+}


### PR DESCRIPTION
This patch adds support for using the functions from the [`salt.modules.status` module] (https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.status.html) with the `callSync`/`callAsync` interfaces. All functions are represented in the new class, the only one I left out is [`master()`] (https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.status.html#salt.modules.status.master), which I was not sure if it makes sense to be called via the API.

I tested all of the return types manually, but they are still very generic for many functions. This can definitely be improved in terms of parsing the data into more specialized objects.
