### PR TITLE
SimpleDateFormat from static variable to local

### DIFF
--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -608,7 +608,7 @@ public class SaltStackClientTest {
     @Test
     public void testJobs() throws Exception {
     	final SimpleDateFormat DATE_FORMAT =
-            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)
@@ -681,7 +681,7 @@ public class SaltStackClientTest {
     @Test
     public void testJobsPending() throws Exception {
     	final SimpleDateFormat DATE_FORMAT =
-            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -99,8 +99,6 @@ public class SaltStackClientTest {
     static final String JSON_LOGOUT_RESPONSE = ClientUtils.streamToString(
             SaltStackClientTest.class.getResourceAsStream("/logout_response.json"));
 
-    private static final SimpleDateFormat DATE_FORMAT =
-            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
@@ -609,6 +607,8 @@ public class SaltStackClientTest {
 
     @Test
     public void testJobs() throws Exception {
+    	final SimpleDateFormat DATE_FORMAT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)
@@ -680,6 +680,8 @@ public class SaltStackClientTest {
 
     @Test
     public void testJobsPending() throws Exception {
+    	final SimpleDateFormat DATE_FORMAT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)

--- a/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/client/SaltStackClientTest.java
@@ -607,8 +607,8 @@ public class SaltStackClientTest {
 
     @Test
     public void testJobs() throws Exception {
-    	final SimpleDateFormat DATE_FORMAT =
-            	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        final SimpleDateFormat DATE_FORMAT =
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)
@@ -680,8 +680,8 @@ public class SaltStackClientTest {
 
     @Test
     public void testJobsPending() throws Exception {
-    	final SimpleDateFormat DATE_FORMAT =
-            	new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        final SimpleDateFormat DATE_FORMAT =
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         stubFor(any(urlMatching(".*"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)


### PR DESCRIPTION
Moved SimpleDateFormat from static variable to local variable inside the
method they are used, because DateFormats are not thread-safe, meaning that
they maintain an internal representation of state. Using them in a static
context can yield some pretty strange bugs if multiple threads access the
same instance simultaneously.

Reference:
https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html#synchronization