### PR TITLE
Add dependency on slf4j-jdk14 logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.3.1</version>


### PR DESCRIPTION
wiremock is pulling in slf4j as its dependency in unit tests, but
because it does not pull in any logging implementation, wiremock's
logs end up in /dev/null.

...
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
...

Adding a JDK logging backend for slf4j gives us wiremock logs.