### PR TITLE
On event stream closure, pass the CloseReason on to the listeners

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/event/EventListener.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventListener.java
@@ -2,6 +2,8 @@ package com.suse.saltstack.netapi.event;
 
 import com.suse.saltstack.netapi.datatypes.Event;
 
+import javax.websocket.CloseReason;
+
 /**
  * Defines a client notification interface for events stream.
  */
@@ -16,6 +18,7 @@ public interface EventListener {
     /**
      * Notify the listener that the backing event stream was closed.  Listener may
      * need to recreate the event stream or take other actions.
+     * @param closeReason the close reason
      */
-    void eventStreamClosed();
+    void eventStreamClosed(CloseReason closeReason);
 }

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.websocket.CloseReason;
 import javax.websocket.DeploymentException;
 
 import java.io.IOException;
@@ -204,7 +205,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void eventStreamClosed() {
+        public void eventStreamClosed(CloseReason closeReason) {
         }
     }
 
@@ -230,7 +231,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void eventStreamClosed() {
+        public void eventStreamClosed(CloseReason closeReason) {
         }
     }
 
@@ -243,7 +244,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void eventStreamClosed() {
+        public void eventStreamClosed(CloseReason closeReason) {
         }
     }
 
@@ -263,7 +264,7 @@ public class TyrusWebSocketEventsTest {
         }
 
         @Override
-        public void eventStreamClosed() {
+        public void eventStreamClosed(CloseReason closeReason) {
         }
     }
 }


### PR DESCRIPTION
This patch makes it easier to debug the websocket based event stream by passing on the [CloseReason] (http://docs.oracle.com/javaee/7/api/javax/websocket/CloseReason.html) to all event listeners whenever the event stream has closed.