### PR TITLE
Buffer partial websocket messages

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -502,8 +502,9 @@ public class SaltStackClient {
      * {@code GET /events}
      *
      * @return the event stream
+     * @throws SaltStackException in case of an error during websocket stream initialization
      */
-    public EventStream events() {
+    public EventStream events() throws SaltStackException {
         return new EventStream(config);
     }
 

--- a/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
+++ b/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
@@ -37,7 +37,7 @@ public class ClientConfig {
     /**
      * Maximum websocket message length in characters. The default value corresponds to
      * 10 MB, assuming that one character takes up 2 bytes. This limit can be disabled
-     * by setting a value <= 0.
+     * by setting a value less than or equal to 0.
      */
     public static final Key<Integer> WEBSOCKET_MAX_MESSAGE_LENGTH = new Key<>(5242880);
 

--- a/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
+++ b/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
@@ -39,7 +39,7 @@ public class ClientConfig {
      * 10 MB, assuming that one character takes up 2 bytes. This limit can be disabled
      * by setting a value less than or equal to 0.
      */
-    public static final Key<Integer> WEBSOCKET_MAX_MESSAGE_LENGTH = new Key<>(5242880);
+    public static final Key<Integer> WEBSOCKET_MAX_MESSAGE_LENGTH = new Key<>(0x500000);
 
     /**
      * A key to use with {@link ClientConfig}.

--- a/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
+++ b/src/main/java/com/suse/saltstack/netapi/config/ClientConfig.java
@@ -35,6 +35,13 @@ public class ClientConfig {
     public static final Key<String> PROXY_PASSWORD = new Key<>();
 
     /**
+     * Maximum websocket message length in characters. The default value corresponds to
+     * 10 MB, assuming that one character takes up 2 bytes. This limit can be disabled
+     * by setting a value <= 0.
+     */
+    public static final Key<Integer> WEBSOCKET_MAX_MESSAGE_LENGTH = new Key<>(5242880);
+
+    /**
      * A key to use with {@link ClientConfig}.
      * @param <T> The type of the value associated with this key.
      */

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -216,7 +216,7 @@ public class EventStream implements AutoCloseable {
                 partialMessageBuffer.append(partialMessage);
                 message = partialMessageBuffer.toString();
             }
-            if (maxMessageLength >= 0 && message.length() > maxMessageLength) {
+            if (maxMessageLength > 0 && message.length() > maxMessageLength) {
                 throw new MessageTooBigException(maxMessageLength);
             }
 
@@ -235,7 +235,7 @@ public class EventStream implements AutoCloseable {
             partialMessageBuffer.setLength(0);
         } else {
             partialMessageBuffer.append(partialMessage);
-            if (maxMessageLength >= 0 && partialMessageBuffer.length() > maxMessageLength) {
+            if (maxMessageLength > 0 && partialMessageBuffer.length() > maxMessageLength) {
                 throw new MessageTooBigException(maxMessageLength);
             }
         }

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -64,7 +64,7 @@ public class EventStream implements AutoCloseable {
     /**
      * The WebSocket {@link Session}.
      */
-    public Session session;
+    private Session session;
 
     /**
      * Constructor used to create this object.

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -248,14 +248,9 @@ public class EventStream implements AutoCloseable {
      * @throws IOException in case of an error when closing the session
      */
     @OnError
-    public void onError(Throwable t) throws IOException {
-        CloseReason closeReason;
-        if (t instanceof MessageTooBigException) {
-            closeReason = new CloseReason(CloseCodes.TOO_BIG, t.getMessage());
-        } else {
-            closeReason = new CloseReason(CloseCodes.CLOSED_ABNORMALLY, t.getMessage());
-        }
-        close(closeReason);
+    public void onError(Throwable throwable) throws IOException {
+        close(new CloseReason(throwable instanceof MessageTooBigException ?
+                CloseCodes.TOO_BIG : CloseCodes.CLOSED_ABNORMALLY, throwable.getMessage()));
     }
 
     /**

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -229,10 +229,10 @@ public class EventStream implements AutoCloseable {
                 }
             }
 
-            // Empty the buffer (and reset size to the defaultBufferSize)
-            partialMessageBuffer.setLength(0);
+            // Reset the size to the defaultBufferSize and empty the buffer
+            partialMessageBuffer.setLength(defaultBufferSize);
             partialMessageBuffer.trimToSize();
-            partialMessageBuffer.ensureCapacity(defaultBufferSize);
+            partialMessageBuffer.setLength(0);
         } else {
             partialMessageBuffer.append(partialMessage);
             if (maxMessageLength >= 0 && partialMessageBuffer.length() > maxMessageLength) {

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -208,6 +208,11 @@ public class EventStream implements AutoCloseable {
     @OnMessage
     public void onMessage(String partialMessage, boolean last)
             throws MessageTooBigException {
+        if (maxMessageLength > 0 && partialMessageBuffer.length() +
+                partialMessage.length() > maxMessageLength) {
+            throw new MessageTooBigException(maxMessageLength);
+        }
+
         if (last) {
             String message;
             if (partialMessageBuffer.length() == 0) {
@@ -221,9 +226,6 @@ public class EventStream implements AutoCloseable {
                 partialMessageBuffer.trimToSize();
                 partialMessageBuffer.setLength(0);
             }
-            if (maxMessageLength > 0 && message.length() > maxMessageLength) {
-                throw new MessageTooBigException(maxMessageLength);
-            }
 
             // Notify all registered listeners
             if (!message.equals("server received message")) {
@@ -235,9 +237,6 @@ public class EventStream implements AutoCloseable {
             }
         } else {
             partialMessageBuffer.append(partialMessage);
-            if (maxMessageLength > 0 && partialMessageBuffer.length() > maxMessageLength) {
-                throw new MessageTooBigException(maxMessageLength);
-            }
         }
     }
 

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -215,6 +215,11 @@ public class EventStream implements AutoCloseable {
             } else {
                 partialMessageBuffer.append(partialMessage);
                 message = partialMessageBuffer.toString();
+
+                // Reset the size to the defaultBufferSize and empty the buffer
+                partialMessageBuffer.setLength(defaultBufferSize);
+                partialMessageBuffer.trimToSize();
+                partialMessageBuffer.setLength(0);
             }
             if (maxMessageLength > 0 && message.length() > maxMessageLength) {
                 throw new MessageTooBigException(maxMessageLength);
@@ -228,11 +233,6 @@ public class EventStream implements AutoCloseable {
                     listeners.stream().forEach(l -> l.notify(event));
                 }
             }
-
-            // Reset the size to the defaultBufferSize and empty the buffer
-            partialMessageBuffer.setLength(defaultBufferSize);
-            partialMessageBuffer.trimToSize();
-            partialMessageBuffer.setLength(0);
         } else {
             partialMessageBuffer.append(partialMessage);
             if (maxMessageLength > 0 && partialMessageBuffer.length() > maxMessageLength) {

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -75,7 +75,8 @@ public class EventStream implements AutoCloseable {
      * @throws SaltStackException in case of an error during stream initialization
      */
     public EventStream(ClientConfig config) throws SaltStackException {
-        maxMessageLength = config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH);
+        maxMessageLength = config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) > 0 ?
+                config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) : Integer.MAX_VALUE;
         initializeStream(config);
     }
 
@@ -208,8 +209,7 @@ public class EventStream implements AutoCloseable {
     @OnMessage
     public void onMessage(String partialMessage, boolean last)
             throws MessageTooBigException {
-        if (maxMessageLength > 0 &&
-                messageBuffer.length() + partialMessage.length() > maxMessageLength) {
+        if (messageBuffer.length() + partialMessage.length() > maxMessageLength) {
             throw new MessageTooBigException(maxMessageLength);
         }
 

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -61,14 +61,6 @@ public class EventStream implements AutoCloseable {
     public Session session;
 
     /**
-     * A default constructor used to create this object empty. It prepare the WebSocket
-     * implementation, but it does not start the connection to the server
-     * and then the event processing too. This constructor is used for unit testing.
-     */
-    public EventStream() {
-    }
-
-    /**
      * Constructor used to create this object.
      * Automatically open a WebSocket and start event processing.
      *

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -230,7 +230,7 @@ public class EventStream implements AutoCloseable {
                 // Salt API adds a "data: " prefix that we need to ignore
                 Event event = JsonParser.EVENTS.parse(message.substring(6));
                 synchronized (listeners) {
-                    listeners.stream().forEach(l -> l.notify(event));
+                    listeners.stream().forEach(listener -> listener.notify(event));
                 }
             }
         } else {
@@ -271,7 +271,7 @@ public class EventStream implements AutoCloseable {
 
         // Notify all the listeners and cleanup
         synchronized (listeners) {
-            listeners.stream().forEach(l -> l.eventStreamClosed(closeReason));
+            listeners.stream().forEach(listener -> listener.eventStreamClosed(closeReason));
 
             // Clear out the listeners
             listeners.clear();

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -209,7 +209,7 @@ public class EventStream implements AutoCloseable {
     @OnMessage
     public void onMessage(String partialMessage, boolean last)
             throws MessageTooBigException {
-        if (messageBuffer.length() + partialMessage.length() > maxMessageLength) {
+        if (partialMessage.length() > maxMessageLength - messageBuffer.length()) {
             throw new MessageTooBigException(maxMessageLength);
         }
 

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -244,7 +244,7 @@ public class EventStream implements AutoCloseable {
     /**
      * On error, convert {@link Throwable} into {@link CloseReason} and close the session.
      *
-     * @param t The Throwable object received on the current error.
+     * @param throwable The Throwable object received on the current error.
      * @throws IOException in case of an error when closing the session
      */
     @OnError

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -43,7 +43,7 @@ public class EventStream implements AutoCloseable {
     /**
      * Default message buffer size in characters.
      */
-    private final int defaultBufferSize = 1024;
+    private final int defaultBufferSize = 0x400;
 
     /**
      * Maximum message length in characters, configurable via {@link ClientConfig}.

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -53,7 +53,7 @@ public class EventStream implements AutoCloseable {
     /**
      * Buffer for partial messages.
      */
-    private final StringBuilder partialMessageBuffer = new StringBuilder(defaultBufferSize);
+    private final StringBuilder messageBuffer = new StringBuilder(defaultBufferSize);
 
     /**
      * The {@link WebSocketContainer} object for a @ClientEndpoint implementation.
@@ -208,23 +208,23 @@ public class EventStream implements AutoCloseable {
     @OnMessage
     public void onMessage(String partialMessage, boolean last)
             throws MessageTooBigException {
-        if (maxMessageLength > 0 && partialMessageBuffer.length() +
-                partialMessage.length() > maxMessageLength) {
+        if (maxMessageLength > 0 &&
+                messageBuffer.length() + partialMessage.length() > maxMessageLength) {
             throw new MessageTooBigException(maxMessageLength);
         }
 
         if (last) {
             String message;
-            if (partialMessageBuffer.length() == 0) {
+            if (messageBuffer.length() == 0) {
                 message = partialMessage;
             } else {
-                partialMessageBuffer.append(partialMessage);
-                message = partialMessageBuffer.toString();
+                messageBuffer.append(partialMessage);
+                message = messageBuffer.toString();
 
                 // Reset the size to the defaultBufferSize and empty the buffer
-                partialMessageBuffer.setLength(defaultBufferSize);
-                partialMessageBuffer.trimToSize();
-                partialMessageBuffer.setLength(0);
+                messageBuffer.setLength(defaultBufferSize);
+                messageBuffer.trimToSize();
+                messageBuffer.setLength(0);
             }
 
             // Notify all registered listeners
@@ -236,7 +236,7 @@ public class EventStream implements AutoCloseable {
                 }
             }
         } else {
-            partialMessageBuffer.append(partialMessage);
+            messageBuffer.append(partialMessage);
         }
     }
 

--- a/src/main/java/com/suse/saltstack/netapi/exception/MessageTooBigException.java
+++ b/src/main/java/com/suse/saltstack/netapi/exception/MessageTooBigException.java
@@ -1,0 +1,18 @@
+package com.suse.saltstack.netapi.exception;
+
+/**
+ * Exception to be thrown in case of a websocket message exceeding the configurable
+ * maximum message length.
+ */
+public class MessageTooBigException extends SaltStackException {
+
+    /**
+     * Constructor.
+     *
+     * @param maxMessageLength the maximum message length to be mentioned in the message
+     */
+    public MessageTooBigException(int maxMessageLength) {
+        super("Message length exceeded the configured maximum (" +
+                maxMessageLength + " characters)");
+    }
+}

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -13,7 +13,6 @@ import javax.websocket.CloseReason;
 import javax.websocket.CloseReason.CloseCodes;
 import javax.websocket.DeploymentException;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -71,9 +70,7 @@ public class TyrusWebSocketEventsTest {
      * Tests: listener insertion, listener notification, stream closed, stream content.
      * Source file contains 6 events: asserts listener notify method is called 6 times.
      *
-     * @throws IOException Exception creating the {@link EventStream}
-     * @throws DeploymentException Exception connecting WebSocket to {@link Server}
-     * @throws InterruptedException Exception using {@link CountDownLatch}
+     * @throws Exception in case of an error
      */
     @Test
     public void shouldFireNotifyMultipleTimes() throws Exception {
@@ -92,9 +89,7 @@ public class TyrusWebSocketEventsTest {
     /**
      * Tests: stream event content
      *
-     * @throws IOException Exception creating the {@link EventStream}
-     * @throws DeploymentException Exception connecting WebSocket to {@link Server}
-     * @throws InterruptedException Exception using {@link CountDownLatch}
+     * @throws Exception in case of an error
      */
     @Test
     public void testEventMessageContent() throws Exception {
@@ -116,7 +111,7 @@ public class TyrusWebSocketEventsTest {
     /**
      * Tests: listener management - count: +1 +1 +1 -1 -1 +1 == 2
      *
-     * @throws IOException Exception creating the {@link EventStream}
+     * @throws Exception in case of an error
      */
     @Test
     public void testListenerManagement() throws Exception {
@@ -158,9 +153,7 @@ public class TyrusWebSocketEventsTest {
     /**
      * Tests: event stream WebSocket session not closed
      *
-     * @throws IOException Exception creating the {@link EventStream}
-     * @throws DeploymentException Exception connecting WebSocket to {@link Server}
-     * @throws InterruptedException Exception using {@link CountDownLatch}
+     * @throws Exception in case of an error
      */
     @Test
     public void testEventStreamClosed() throws Exception {

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -126,7 +126,7 @@ public class TyrusWebSocketEventsTest {
         SimpleEventListenerClient client3 = new SimpleEventListenerClient();
         SimpleEventListenerClient client4 = new SimpleEventListenerClient();
 
-        try (EventStream streamEvents = new EventStream()) {
+        try (EventStream streamEvents = new EventStream(clientConfig)) {
             streamEvents.addEventListener(client1);
             streamEvents.addEventListener(client2);
             streamEvents.addEventListener(client3);

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -138,9 +138,9 @@ public class TyrusWebSocketEventsTest {
     }
 
     /**
-     * Tests: event processing WebSocket session not open
+     * Test event processing websocket session closed by the listener.
      *
-     * @throws IOException Exception creating the {@link EventStream}
+     * @throws Exception in case of an error
      */
     @Test
     public void testEventProcessingStateStopped() throws Exception {
@@ -149,6 +149,10 @@ public class TyrusWebSocketEventsTest {
         streamEvents.addEventListener(eventListener);
         streamEvents.close();
         Assert.assertTrue(streamEvents.isEventStreamClosed());
+        Assert.assertEquals(CloseCodes.GOING_AWAY,
+                eventListener.closeReason.getCloseCode());
+        String message = "The listener has closed the event stream";
+        Assert.assertEquals(message, eventListener.closeReason.getReasonPhrase());
     }
 
     /**
@@ -262,12 +266,15 @@ public class TyrusWebSocketEventsTest {
      * Simple Event ListenerClient
      */
     private class SimpleEventListenerClient implements EventListener {
+        CloseReason closeReason;
+
         @Override
         public void notify(Event event) {
         }
 
         @Override
         public void eventStreamClosed(CloseReason closeReason) {
+            this.closeReason = closeReason;
         }
     }
 

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -38,7 +38,7 @@ public class TyrusWebSocketEventsTest {
     /**
      * The WebSocket URI path to connect to the server.
      */
-    private URI ws_uri;
+    private URI wsUri;
 
     /**
      * Client configuration used in every test
@@ -59,12 +59,12 @@ public class TyrusWebSocketEventsTest {
                 null, WebSocketServerSalt.class);
         serverEndpoint.start();
 
-        ws_uri = new URI("ws://" + MOCK_HTTP_HOST + ":" + MOCK_HTTP_PORT)
+        wsUri = new URI("ws://" + MOCK_HTTP_HOST + ":" + MOCK_HTTP_PORT)
                 .resolve(WEBSOCKET_PATH);
 
         clientConfig = new ClientConfig();
         clientConfig.put(ClientConfig.TOKEN, "token");
-        clientConfig.put(ClientConfig.URL, ws_uri);
+        clientConfig.put(ClientConfig.URL, wsUri);
     }
 
     /**

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -75,8 +75,7 @@ public class TyrusWebSocketEventsTest {
      * @throws InterruptedException Exception using {@link CountDownLatch}
      */
     @Test
-    public void shouldFireNotifyMultipleTimes()
-            throws IOException, DeploymentException, InterruptedException {
+    public void shouldFireNotifyMultipleTimes() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         int target = 6;
 
@@ -97,8 +96,7 @@ public class TyrusWebSocketEventsTest {
      * @throws InterruptedException Exception using {@link CountDownLatch}
      */
     @Test
-    public void testEventMessageContent()
-            throws IOException, DeploymentException, InterruptedException {
+    public void testEventMessageContent() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
         try (EventStream streamEvents = new EventStream(clientConfig)) {
@@ -120,7 +118,7 @@ public class TyrusWebSocketEventsTest {
      * @throws IOException Exception creating the {@link EventStream}
      */
     @Test
-    public void testListenerManagement() throws IOException {
+    public void testListenerManagement() throws Exception {
         SimpleEventListenerClient client1 = new SimpleEventListenerClient();
         SimpleEventListenerClient client2 = new SimpleEventListenerClient();
         SimpleEventListenerClient client3 = new SimpleEventListenerClient();
@@ -144,7 +142,7 @@ public class TyrusWebSocketEventsTest {
      * @throws IOException Exception creating the {@link EventStream}
      */
     @Test
-    public void testEventProcessingStateStopped() throws IOException {
+    public void testEventProcessingStateStopped() throws Exception {
         EventStream streamEvents = new EventStream(clientConfig);
         SimpleEventListenerClient eventListener = new SimpleEventListenerClient();
         streamEvents.addEventListener(eventListener);
@@ -160,8 +158,7 @@ public class TyrusWebSocketEventsTest {
      * @throws InterruptedException Exception using {@link CountDownLatch}
      */
     @Test
-    public void testEventStreamClosed()
-            throws IOException, DeploymentException, InterruptedException {
+    public void testEventStreamClosed() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
         try (EventStream streamEvents = new EventStream(clientConfig)) {

--- a/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/saltstack/netapi/event/TyrusWebSocketEventsTest.java
@@ -289,8 +289,8 @@ public class TyrusWebSocketEventsTest {
 
         @Override
         public void eventStreamClosed(CloseReason closeReason) {
-            this.latch.countDown();
             this.closeReason = closeReason;
+            this.latch.countDown();
         }
     }
 }


### PR DESCRIPTION
This patch adds support for buffering partial websocket messages in `EventStream` by implementing [`MessageHandler.Partial`] (http://docs.oracle.com/javaee/7/api/javax/websocket/MessageHandler.Partial.html). A configurable limit on the allowed message length is introduced that can be disabled by setting a value less than or equal to 0. Partial messages will be buffered and listeners get notified only when the last message has been received. The stream will be closed with a suitable [`CloseReason`] (http://docs.oracle.com/javaee/7/api/javax/websocket/CloseReason.html) if the buffer grows beyond the maximum length.

This is what you get without this patch using Tomcat as client and receiving a "big" event:
```
Event stream closed: The decoded text message was too big for the output buffer and the endpoint does not support partial messages [TOO_BIG]
```