### PR TITLE
Move sync/async remote call setups to their respective classes

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/saltstack/netapi/calls/LocalCall.java
@@ -1,7 +1,15 @@
 package com.suse.saltstack.netapi.calls;
 
 import com.google.gson.reflect.TypeToken;
+import com.suse.saltstack.netapi.AuthModule;
+import com.suse.saltstack.netapi.client.SaltStackClient;
+import com.suse.saltstack.netapi.datatypes.target.Target;
+import com.suse.saltstack.netapi.exception.SaltStackException;
+import com.suse.saltstack.netapi.results.Result;
 
+import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
+
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,5 +49,129 @@ public class LocalCall<R> implements Call<R> {
         arg.ifPresent(arg -> payload.put("arg", arg));
         kwarg.ifPresent(kwarg -> payload.put("kwarg", kwarg));
         return payload;
+    }
+
+    /**
+     * Calls a execution module function on the given target asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the token therefore you have to login prior
+     * to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @param target the target for the function
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public LocalAsyncResult<R> callAsync(final SaltStackClient client, Target<?> target)
+            throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("tgt", target.getTarget());
+        customArgs.put("expr_form", target.getType());
+
+        Result<List<LocalAsyncResult<R>>> wrapper = client.call(
+                this, Client.LOCAL_ASYNC, "/",
+                Optional.of(customArgs),
+                new TypeToken<Result<List<LocalAsyncResult<R>>>>(){});
+        LocalAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a execution module function on the given target asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the given credentials no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param target the target for the function
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public LocalAsyncResult<R> callAsync(final SaltStackClient client, Target<?> target,
+            String username, String password, AuthModule authModule)
+            throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+        customArgs.put("tgt", target.getTarget());
+        customArgs.put("expr_form", target.getType());
+
+        Result<List<LocalAsyncResult<R>>> wrapper = client.call(
+                this, Client.LOCAL_ASYNC, "/run",
+                Optional.of(customArgs),
+                new TypeToken<Result<List<LocalAsyncResult<R>>>>(){});
+        LocalAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a execution module function on the given target and synchronously
+     * waits for the result. Authentication is done with the token therefore you
+     * have to login prior to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @param target the target for the function
+     * @return a map containing the results with the minion name as key
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Map<String, R> callSync(final SaltStackClient client, Target<?> target)
+            throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.put("tgt", target.getTarget());
+        customArgs.put("expr_form", target.getType());
+
+        Type type = parameterizedType(null, Map.class, String.class,
+                getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, type);
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<Map<String, R>>> wrapper = client.call(this, Client.LOCAL, "/",
+                Optional.of(customArgs),
+                (TypeToken<Result<List<Map<String, R>>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
+    }
+
+    /**
+     * Calls a execution module function on the given target and synchronously
+     * waits for the result. Authentication is done with the given credentials
+     * no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param target the target for the function
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return a map containing the results with the minion name as key
+     * @throws SaltStackException if anything goes wrong
+     */
+    public Map<String, R> callSync(final SaltStackClient client, Target<?> target,
+            String username, String password, AuthModule authModule)
+            throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+        customArgs.put("tgt", target.getTarget());
+        customArgs.put("expr_form", target.getType());
+
+        Type mapType = parameterizedType(null, Map.class, String.class,
+                getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, mapType);
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<Map<String, R>>> wrapper = client.call(this, Client.LOCAL, "/run",
+                Optional.of(customArgs),
+                (TypeToken<Result<List<Map<String, R>>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
     }
 }

--- a/src/main/java/com/suse/saltstack/netapi/calls/RunnerCall.java
+++ b/src/main/java/com/suse/saltstack/netapi/calls/RunnerCall.java
@@ -1,8 +1,16 @@
 package com.suse.saltstack.netapi.calls;
 
 import com.google.gson.reflect.TypeToken;
+import com.suse.saltstack.netapi.AuthModule;
+import com.suse.saltstack.netapi.client.SaltStackClient;
+import com.suse.saltstack.netapi.exception.SaltStackException;
+import com.suse.saltstack.netapi.results.Result;
 
+import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
+
+import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,4 +46,103 @@ public class RunnerCall<R> implements Call<R> {
         kwargs.ifPresent(kwargs -> payload.put("kwargs", kwargs));
         return payload;
     }
+
+    /**
+     * Calls a runner module function on the master asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the token therefore you have to login prior
+     * to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public RunnerAsyncResult<R> callAsync(final SaltStackClient client)
+            throws SaltStackException {
+        Result<List<RunnerAsyncResult<R>>> wrapper = client.call(
+                this, Client.RUNNER_ASYNC, "/",
+                new TypeToken<Result<List<RunnerAsyncResult<R>>>>(){});
+        RunnerAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a runner module function on the master asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the given credentials no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public RunnerAsyncResult<R> callAsync(final SaltStackClient client, String username,
+            String password, AuthModule authModule) throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+
+        Result<List<RunnerAsyncResult<R>>> wrapper = client.call(
+                this, Client.RUNNER_ASYNC, "/run",
+                Optional.of(customArgs),
+                new TypeToken<Result<List<RunnerAsyncResult<R>>>>(){});
+        RunnerAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a runner module function on the master and synchronously
+     * waits for the result. Authentication is done with the given credentials
+     * no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return the result of the called function
+     * @throws SaltStackException if anything goes wrong
+     */
+    public R callSync(final SaltStackClient client, String username, String password,
+            AuthModule authModule) throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+
+        Type listType = parameterizedType(null, List.class, getReturnType().getType());
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<R>> wrapper = client.call(
+                this, Client.RUNNER, "/run", Optional.of(customArgs),
+                (TypeToken<Result<List<R>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
+    }
+
+    /**
+     * Calls a runner module function on the master and synchronously
+     * waits for the result. Authentication is done with the token therefore you
+     * have to login prior to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @return the result of the called function
+     * @throws SaltStackException if anything goes wrong
+     */
+    public R callSync(final SaltStackClient client) throws SaltStackException {
+        Type listType = parameterizedType(null, List.class, getReturnType().getType());
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<R>> wrapper = client.call(this, Client.RUNNER, "/",
+                (TypeToken<Result<List<R>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
+    }
+
 }

--- a/src/main/java/com/suse/saltstack/netapi/calls/WheelCall.java
+++ b/src/main/java/com/suse/saltstack/netapi/calls/WheelCall.java
@@ -1,8 +1,16 @@
 package com.suse.saltstack.netapi.calls;
 
 import com.google.gson.reflect.TypeToken;
+import com.suse.saltstack.netapi.AuthModule;
+import com.suse.saltstack.netapi.client.SaltStackClient;
+import com.suse.saltstack.netapi.exception.SaltStackException;
+import com.suse.saltstack.netapi.results.Result;
 
+import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
+
+import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,5 +45,109 @@ public class WheelCall<R> implements Call<R> {
         payload.put("fun", functionName);
         kwargs.ifPresent(payload::putAll);
         return payload;
+    }
+
+    /**
+     * Calls a wheel module function on the master asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the token therefore you have to login prior
+     * to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public WheelAsyncResult<R> callAsync(final SaltStackClient client)
+            throws SaltStackException {
+        Result<List<WheelAsyncResult<R>>> wrapper = client.call(
+                this, Client.WHEEL_ASYNC, "/",
+                new TypeToken<Result<List<WheelAsyncResult<R>>>>(){});
+        WheelAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a wheel module function on the master asynchronously and
+     * returns information about the scheduled job that can be used to query the result.
+     * Authentication is done with the given credentials no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return information about the scheduled job
+     * @throws SaltStackException if anything goes wrong
+     */
+    public WheelAsyncResult<R> callAsync(final SaltStackClient client, String username,
+            String password, AuthModule authModule) throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+
+        Result<List<WheelAsyncResult<R>>> wrapper = client.call(
+                this, Client.WHEEL_ASYNC, "/run",
+                Optional.of(customArgs),
+                new TypeToken<Result<List<WheelAsyncResult<R>>>>(){});
+        WheelAsyncResult<R> result = wrapper.getResult().get(0);
+        result.setType(getReturnType());
+        return result;
+    }
+
+    /**
+     * Calls a wheel module function on the master and synchronously
+     * waits for the result. Authentication is done with the token therefore you
+     * have to login prior to using this function.
+     *
+     * @param client connection instance with Saltstack
+     * @return the result of the called function
+     * @throws SaltStackException if anything goes wrong
+     */
+    public WheelResult<R> callSync(final SaltStackClient client)
+            throws SaltStackException {
+        Type wheelResult = parameterizedType(null, WheelResult.class,
+                getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, wheelResult);
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/",
+                (TypeToken<Result<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
+    }
+
+    /**
+     * Calls a wheel module function on the master and synchronously
+     * waits for the result. Authentication is done with the given credentials
+     * no session token is created.
+     *
+     * @param client connection instance with Saltstack
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @return the result of the called function
+     * @throws SaltStackException if anything goes wrong
+     */
+    public WheelResult<R> callSync(final SaltStackClient client,
+            String username, String password,
+            AuthModule authModule) throws SaltStackException {
+        Map<String, Object> customArgs = new HashMap<>();
+        customArgs.putAll(getPayload());
+        customArgs.put("username", username);
+        customArgs.put("password", password);
+        customArgs.put("eauth", authModule.getValue());
+
+        Type wheelResult = parameterizedType(null, WheelResult.class,
+                getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, wheelResult);
+        Type wrapperType = parameterizedType(null, Result.class, listType);
+
+        @SuppressWarnings("unchecked")
+        Result<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/run",
+                Optional.of(customArgs),
+                (TypeToken<Result<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
+        return wrapper.getResult().get(0);
     }
 }


### PR DESCRIPTION
There is no logic changes. The only major change is that the generic
SaltStackClient.call() function is now exposed as a public function.

Issue: #99 

As always, comments are welcome.
