### PR TITLE
Allow adding event listeners before stream initialization

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -22,6 +22,7 @@ import com.suse.saltstack.netapi.datatypes.ScheduledJob;
 import com.suse.saltstack.netapi.datatypes.Token;
 import com.suse.saltstack.netapi.datatypes.cherrypy.Stats;
 import com.suse.saltstack.netapi.datatypes.target.Target;
+import com.suse.saltstack.netapi.event.EventListener;
 import com.suse.saltstack.netapi.event.EventStream;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
@@ -507,11 +508,12 @@ public class SaltStackClient {
      * <p>
      * {@code GET /events}
      *
+     * @param listeners event listeners to be added before the stream is initialized
      * @return the event stream
      * @throws SaltStackException in case of an error during websocket stream initialization
      */
-    public EventStream events() throws SaltStackException {
-        return new EventStream(config);
+    public EventStream events(EventListener... listeners) throws SaltStackException {
+        return new EventStream(config, listeners);
     }
 
     /**

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -100,9 +100,8 @@ public class EventStream implements AutoCloseable {
 
             // Initiate the websocket handshake
             synchronized (websocketContainer) {
-                this.session = websocketContainer.connectToServer(this, uri);
-                this.session.setMaxIdleTimeout(
-                        (long) config.get(ClientConfig.SOCKET_TIMEOUT));
+                session = websocketContainer.connectToServer(this, uri);
+                session.setMaxIdleTimeout((long) config.get(ClientConfig.SOCKET_TIMEOUT));
             }
         } catch (URISyntaxException | DeploymentException | IOException e) {
             throw new SaltStackException(e);

--- a/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/saltstack/netapi/event/EventStream.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -67,16 +68,18 @@ public class EventStream implements AutoCloseable {
     private Session session;
 
     /**
-     * Constructor used to create this object.
-     * Automatically open a WebSocket and start event processing.
+     * Constructor used to create an event stream: open a websocket connection and start
+     * event processing.
      *
-     * @param config Contains the necessary details such as EndPoint URL and
-     * authentication token required to create the WebSocket.
+     * @param config client configuration containing the URL, token, timeouts, etc.
+     * @param listeners event listeners to be added before stream initialization
      * @throws SaltStackException in case of an error during stream initialization
      */
-    public EventStream(ClientConfig config) throws SaltStackException {
+    public EventStream(ClientConfig config, EventListener... listeners)
+            throws SaltStackException {
         maxMessageLength = config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) > 0 ?
                 config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) : Integer.MAX_VALUE;
+        Arrays.asList(listeners).forEach(this::addEventListener);
         initializeStream(config);
     }
 


### PR DESCRIPTION
This patch allows to add event listeners to the websocket based event stream before the stream will actually be initialized. This way we can be sure that we won't miss any events between the handshake and adding the listener, which especially helps to make the unit tests more stable (see `TyrusWebSocketEventsTest`).