### PR TITLE
Fix run json

### DIFF
--- a/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
+++ b/src/main/java/com/suse/saltstack/netapi/client/SaltStackClient.java
@@ -1,5 +1,19 @@
 package com.suse.saltstack.netapi.client;
 
+import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -27,22 +41,7 @@ import com.suse.saltstack.netapi.event.EventStream;
 import com.suse.saltstack.netapi.exception.SaltStackException;
 import com.suse.saltstack.netapi.parser.JsonParser;
 import com.suse.saltstack.netapi.results.Result;
-import com.suse.saltstack.netapi.results.ResultInfo;
 import com.suse.saltstack.netapi.results.ResultInfoSet;
-
-import java.lang.reflect.Type;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import static com.suse.saltstack.netapi.utils.ClientUtils.parameterizedType;
 
 /**
  * SaltStack API client.
@@ -392,7 +391,7 @@ public class SaltStackClient {
      * @return Map key: minion id, value: command result from that minion
      * @throws SaltStackException if anything goes wrong
      */
-    public <T> ResultInfo run(final String username, final String password,
+    public <T> Map<String, Object> run(final String username, final String password,
             final AuthModule eauth, final String client, final Target<T> target,
             final String function, List<Object> args, Map<String, Object> kwargs)
             throws SaltStackException {
@@ -411,12 +410,12 @@ public class SaltStackClient {
 
         String payload = gson.toJson(list);
 
-        ResultInfoSet result = connectionFactory
-                .create("/run", JsonParser.JOB_RESULTS, config)
+        Result<List<Map<String, Object>>> result = connectionFactory
+                .create("/run", JsonParser.RUN_RESULTS, config)
                 .getResult(payload);
 
         // A list with one element is returned, we take the first
-        return result.get(0);
+        return result.getResult().get(0);
     }
 
     /**
@@ -435,7 +434,7 @@ public class SaltStackClient {
      * @param kwargs map containing keyword arguments
      * @return Future containing Map key: minion id, value: command result from that minion
      */
-    public <T> Future<ResultInfo> runAsync(final String username,
+    public <T> Future<Map<String, Object>> runAsync(final String username,
             final String password, final AuthModule eauth, final String client,
             final Target<T> target, final String function, final List<Object> args,
             final Map<String, Object> kwargs) {

--- a/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/saltstack/netapi/parser/JsonParser.java
@@ -57,6 +57,8 @@ public class JsonParser<T> {
     public static final JsonParser<Result<List<Map<String, Map<String, Object>>>>> RETMAPS =
             new JsonParser<>(
             new TypeToken<Result<List<Map<String, Map<String, Object>>>>>(){});
+    public static final JsonParser<Result<List<Map<String, Object>>>> RUN_RESULTS =
+            new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
     public static final JsonParser<Stats> STATS =
             new JsonParser<>(new TypeToken<Stats>(){});
     public static final JsonParser<Result<Key.Names>> KEYS =

--- a/src/test/resources/jobs_run_response.json
+++ b/src/test/resources/jobs_run_response.json
@@ -1,0 +1,59 @@
+{
+   "return" : [
+      {
+         "minion-1" : {
+            "i3status" : {
+               "old" : "",
+               "new" : "2.9-2"
+            },
+            "i3" : {
+               "old" : "",
+               "new" : "4.10.3-1"
+            },
+            "i3lock" : {
+               "new" : "2.7-1",
+               "old" : ""
+            }
+         }
+      }
+   ],
+   "info" : [
+      {
+         "Minions" : [
+            "minion-1"
+         ],
+         "Function" : "pkg.install",
+         "Arguments" : [
+            "i3",
+            {
+               "__kwarg__" : true,
+               "sysupgrade" : "false",
+               "refresh" : "true"
+            }
+         ],
+         "Target" : "*",
+         "jid" : "20150810200316696112",
+         "Result" : {
+            "minion-1" : {
+               "return" : {
+                  "i3lock" : {
+                     "old" : "",
+                     "new" : "2.7-1"
+                  },
+                  "i3" : {
+                     "old" : "",
+                     "new" : "4.10.3-1"
+                  },
+                  "i3status" : {
+                     "old" : "",
+                     "new" : "2.9-2"
+                  }
+               }
+            }
+         },
+         "User" : "adamm",
+         "Target-type" : "glob",
+         "StartTime" : "2015, Aug 10 20:03:16.696112"
+      }
+   ]
+}

--- a/src/test/resources/run_response.json
+++ b/src/test/resources/run_response.json
@@ -16,44 +16,5 @@
             }
          }
       }
-   ],
-   "info" : [
-      {
-         "Minions" : [
-            "minion-1"
-         ],
-         "Function" : "pkg.install",
-         "Arguments" : [
-            "i3",
-            {
-               "__kwarg__" : true,
-               "sysupgrade" : "false",
-               "refresh" : "true"
-            }
-         ],
-         "Target" : "*",
-         "jid" : "20150810200316696112",
-         "Result" : {
-            "minion-1" : {
-               "return" : {
-                  "i3lock" : {
-                     "old" : "",
-                     "new" : "2.7-1"
-                  },
-                  "i3" : {
-                     "old" : "",
-                     "new" : "4.10.3-1"
-                  },
-                  "i3status" : {
-                     "old" : "",
-                     "new" : "2.9-2"
-                  }
-               }
-            }
-         },
-         "User" : "adamm",
-         "Target-type" : "glob",
-         "StartTime" : "2015, Aug 10 20:03:16.696112"
-      }
    ]
 }


### PR DESCRIPTION
Fixed parsing for `cmd.run` (new versions of Saltstack should only return "A dictionary with the result 
of the execution, keyed by minion ID. A compound command will return a sub-dictionary 
keyed by function name.").
Adjusting parser accordingly.

Fix #126 